### PR TITLE
Deploy Game Engine Service v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Game engine service for `Blef`
 > The API service to create manage and run games of Blef
 
+![CI](https://github.com/maciej-pomykala/blef_game_engine/workflows/CI/badge.svg?branch=master)
+
 This repository contains the code to run the Blef game engine API service.
 
 At the initial stage it consists of a few basic endpoints, to create, join, start and run a game.


### PR DESCRIPTION
It's been failing all along because the EC2 instance needed manual cleaning.
Deploying v1.0