### PR TITLE
Big rules expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,63 +63,52 @@ There are 88 sets in the game. They are the following:
 
 where X and Y are one of: 9, 10, J, Q, K, or A (in this order of seniority), and C is one of club, diamond, heart, or spade (in this order of seniority). When betting two pair, X must be more senior than than Y. If two pair sets or full house sets are compared, the one with the more senior X is more senior overall. If X is equal in both, the one with the more senior Y is more senior overall.
 
+## Custom rules and game variants
+
+While Blef has a standard set of rules, this game engine allows for several variations that can be configured by the game admin before the game begins.
+
+### Deck size
+
+By default, the game is played with a 24-card deck (9 through Ace). However, you can opt to use a 32-card deck, which adds the 7s and 8s to the card pool.
+
+### Common cards (shared hand)
+
+Instead of all cards being held in private hands, players can play with "common cards". These are cards dealt face up (always visible to every player).
+
+### Jokers and blanks
+
+Special cards can be introduced to the deck:
+* Jokers: These cards can act as a wildcard, substituting for any card a player needs to complete a set. A player can use their own jokers or the jokers on the common hand to complete a set they bet on, upon being checked.
+* Blanks: These are inert cards with no value or suit. They do not contribute to any set, effectively reducing the number of active cards in play and making all sets harder to achieve.
+
+### Time limit
+
+For a faster-paced game, you can introduce a time limit for each player's turn. If a player fails to make a move within the allotted time, they automatically lose the round.
+
 ## How we implement the game
 
-The game is implemented in the form of an API service deployed using a serverless infrastructure on Amazon Web Services. The API has endpoints fulfilling the following roles respectively:
+The game is implemented as a serverless API that handles all aspects of game management, from creation to completion. The service exposes a set of endpoints that allow clients to perform actions such as creating and joining games, managing players and rules, and making moves during gameplay.
 
-* letting a user create a game room
-* letting a player join a game room
-* letting the first player in a game room start the game
-* informing a user about the state of a given game
-* letting a player make a move in a game
+The API provides the following functionalities:
 
-### Creating a game
+* Game lobby management: create a game, list public games, and manage a game's visibility (public/private).
+* Player management: join a game, invite or remove AI players, and signal readiness to start.
+* Rule customization: the game admin can change rules like deck size and time limits before the game begins.
+* Game progression: make a move (bet or check), and query the current or past state of the game.
+* Real-time interaction: send emoji reactions within the game or the public game lobby.
 
-At first, a user has to create a game. This action creates and saves a game object on the API server. As part of this, the relevant API endpoint provisions a unique UUID for the game and informs the user who created the game of this UUID.
-
-### Joining a game
-
-Then, the user who created the game informs other users with whom they want to play of the unique UUID of the game. Using that UUID, users can join the game. Each player has a unique nickname (picked by them) by which they will be known to other players and observers and a unique UUID, which is provisioned by the server, relayed to the player and used for authentication when checking own cards or making moves (and therefore intended to be private). The user who creates the game has to join the game in the same way - they are not automatically enrolled at the point the game is created.
-
-### Starting a game
-
-The first user to join the game is made the 'admin'. Users know the nickname of the admin. The admin, using their player UUID for authentication, will start the game, at which point no more players can join it.
-
-The players are shuffled - i.e. the order of the players in the game (the order in which players make bets) may not be the one in which players join the game. In particular, the game admin might not be the starting player in the first round.
-
-The maximum number of cards is a deterministic function of the number of players who are starting the game. It is equal to 24 (the number of cards available) divided by the number of players and rounded downwards. This ensures that at no point more cards will be needed than are available in the deck. The rule has one exception. With 2 players, the maximum number of cards is 11, not 12. This is because there is a simple strategy to ensure that the first player who reaches 12 cards loses the game. Specifically, in order for them to win the game, it would require the other player to also reach 12 cards and lose a round. However, when the second player reaches 12 cards this player will begin the final round and, knowing that each of the 24 cards is owned by either of the two players, can bet the highest set (Great flush spades) and be guaranteed a win.
-
-### Querying the game state
-
-Players and observers can query the state of the game, choosing either to get the latest state of the game or the state at the end of a specific round. If a user requests to see the state of the game at the end of a past round, they will be shown all cards possessed by each player in that round. However, when users query the current state of the game, they will not be shown any cards unless they provide a valid player UUID to authenticate themselves as a specific player. In that case, they will be shown the cards of that player.
-
-Users can query the (current or past, as mentioned above) state of the game at any point. When they do so, they get the following information about the game:
-
-* the nickname of the admin
-* whether the game is public
-* the status of the game
-* the round number (starting at 1 and incremented by 1 every time a round ends)
-* the maximum number of cards permitted for a player
-* the nicknames of the players who are still participating in the game at the given point, together with the number of cards that each of these players have
-* the cards of the players. This field is either empty (for an ongoing round reported to an observer), filled with the cards of one player (for an ongoing round reported to an authenticated player) or filled with the cards of each player (for a finished round)
-* the nickname of the player who is now supposed to make a move
-* the history of the events in the (current or past) round. An event is a player making a bet (of which there will be at least one but potentially many in a given round), a player checking another player (which will happen once by the end of the round) or a player losing a round (which will be recorded as the last event of that round).
-
-By recording the current state of the game and snapshots of the game at the end of each round, the API will preserve virtually all strategic information about the game (except for details such as the time taken for a user to make a move) and eliminate the need for players or observers to make notes if they would like to learn from the game.
-
-### Making a move
-
-There is an endpoint dedicated to letting the current player make a move. The player provides their UUID (for authentication) and the action they are trying to make (a bet or a check), represented with an action ID.
-
-### Public / private games
-
-A public game is visible to any observer. A private game can only be seen by the users who have its UUID. A game starts private and it can be made public by the admin of the game requesting such change from a dedicated API endpoint. The admin can also switch the game back to private using a different endpoint. This feature is intended to facilitate players joining a game and therefore, when a game starts, it is made private.
-
-Finally, there is an endpoint which allows a user to see all public games (their UUID and list of players).
-
-### Full API documentation
+To take any actions or set their status, the admin or other players need to authenticate themselves by providing their UUID, which is given to them upon joining.
 
 In order to interact with the engine using a custom app or a basic HTTP interface, one should use the full API documentation available in the [API readme](api/README.md).
+
+## Technology stack
+
+This service is built with a serverless architecture on AWS and includes:
+
+* **API:** AWS API Gateway (HTTP & WebSocket)
+* **Compute:** AWS Lambda functions in Python
+* **Database:** AWS DynamoDB
+* **Messaging:** AWS SQS
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the code to run the Blef game engine API service.
 
  * [Blef AI](https://github.com/Blef-team/blef_ai)
 
-## The rules of the game
+## The standard rules of the game
 
 *Blef* is a Polish* card game inspired by Poker. In the game, each player has a certain number of playing cards between 9 and Ace, each card only known to its owner, and players have to make guesses about other players' cards.
 

--- a/api/README.md
+++ b/api/README.md
@@ -129,7 +129,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/set-readiness?player_uuid
     * `common_cards`: integer (0-12)
     * `jokers`: integer (0-12)
     * `blanks`: integer (0-12)
-    * `standard_order`: boolean
 
 * **Sample Call:**
 
@@ -401,7 +400,7 @@ Action IDs are determined dynamically based on the `deck_size` rule.
 * **24-Card Deck:** `action_id` ranges from 0 to 87 for bets. **88 is a check.**
 * **32-Card Deck:** `action_id` ranges from 0 to 139 for bets. **140 is a check.**
 
-The seniority of bets is calculated programmatically. A higher `action_id` represents betting on a more senior set. However, if the betting order is reversed, players can only bet on less senior sets (or check, if applicable).
+A higher `action_id` represents betting on a more senior set.
 
 | Action ID | Set description                      |
 |-----------|--------------------------------------|

--- a/api/README.md
+++ b/api/README.md
@@ -1,8 +1,8 @@
-## Documentation of endpoints
+# HTTP API endpoints
 
-**Create game**
-  ----
-  Creates an empty game object with default rules. Optionally, joins the newly created game.
+## Create game
+
+  Creates a game object with default rules. Optionally, allows joining the newly created game.
 
 * **URL**
 
@@ -29,9 +29,9 @@
 curl <HOST>/games/create
 ```
 
-**Join game**
-  ----
-  Allows a player to join a specific game under a specific nickname. Joining a game will reset the 'ready' status of all human players.
+## Join game
+
+  Allows a player to join a specific game under a specific nickname. They get a UUID provisioned by the engine, relayed in the response and used for authentication when checking own cards or making moves (and therefore intended to be private). The player UUID should be stored, as it will not be revealed again. The first user to join the game is made the 'admin'. Users know the nickname of the admin.
 
 * **URL**
 
@@ -65,9 +65,91 @@ curl <HOST>/games/create
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat
 ```
 
-**Set Readiness**
-  ----
-  Allows a player to set their readiness state. If all players are ready and there are at least 2, the game will start automatically.
+## Invite AI agent
+
+Allows the game admin to add an AI player to the game before it starts.
+
+* **URL**
+
+  /games/{game_uuid}/invite-aiagent
+
+* **URL Params**
+
+  **Required:**
+
+  `"game_uuid"=string`
+
+* **Data Params**
+
+  **Required:**
+
+  `"admin_uuid"=string`
+  `"agent_name"=string`
+
+* **Success Response:**
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"alpha_1_(AI) joined the game"}`
+
+* **Sample Error Response:**
+
+  * **Code:** 403 FORBIDDEN <br />
+  **Content:** `{"error":"Game room full"}`
+
+* **Sample Call:**
+
+```
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/invite-aiagent?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&agent_name=alpha
+```
+
+## Remove AI agents
+
+Allows the game admin to remove all AI players from the game before it starts.
+
+* **URL**
+
+  /games/{game_uuid}/remove-ais
+
+* **URL Params**
+
+  **Required:**
+
+  `"game_uuid"=string`
+
+* **Data Params**
+
+  **Required:**
+
+  `"admin_uuid"=string`
+
+* **Success Response:**
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"All AI players have been removed."}`
+
+  OR
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"No AI players to remove."}`
+
+* **Sample Error Response:**
+
+  * **Code:** 403 FORBIDDEN <br />
+  **Content:** `{"error":"Cannot remove AIs after the game has started"}`
+
+* **Sample Call:**
+
+```
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/remove-ais?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d
+```
+
+## Set readiness
+
+  Allows a player to set their readiness state. If all players are ready and there are at least 2, the game will start automatically. At this point, no more players can join it. Readiness is also used to start new rounds of a timed game.
+
+  When a game starts, the players are shuffled - i.e. the order of the players in the game (the order in which players make bets) may not be the one in which players join the game. In particular, the game admin might not be the starting player in the first round.
+
+  Each time a game or a round starts, cards are shuffled and dealt randomly.
 
 * **URL**
 
@@ -97,9 +179,9 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/set-readiness?player_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&ready=True
 ```
 
-**Change Rules**
-  ----
-  Allows the game admin to change the rules of the game before it starts. Changing rules will reset the readiness of all human players.
+## Change rules
+
+  Allows the game admin to change the rules of the game before it starts. This includes changing the maximum number of cards. However, if the preference regarding eh maximum number of cards cannot be satisfied, the highest feasible number will be chosen. If there is no preference, the engine will suggest a number, which will be displayed in the `max_cards` field of teh game state.
 
 * **URL**
 
@@ -129,6 +211,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/set-readiness?player_uuid
     * `common_cards`: integer (0-12)
     * `jokers`: integer (0-12)
     * `blanks`: integer (0-12)
+    * `max_cards`: integer (0-11, where 0 indicates no preference)
 
 * **Sample Call:**
 
@@ -136,9 +219,11 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/set-readiness?player_uuid
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&rules={"common_cards":4}
 ```
 
-**Start game (Legacy)**
-  ----
-  Allows the first player who joined the game to start it. **This is a legacy endpoint.** The recommended way to start a game is for all players to set their readiness to `true`.
+## Start game
+
+  Allows the admin to start the game. See the documentation for set_readiness to know more about game starts. 
+  
+  Cannot be used to start a game with a time limit.
 
 * **URL**
 
@@ -170,9 +255,25 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849-44e9-4211-8a21-63c4a9a91d53
 ```
 
-**Get game state**
-  ----
-  Allows a user to query the current (or past) state of the game, restricting information about players hands as appropriate.
+## Get game state
+
+  Players and observers can query the state of the game, choosing either to get the latest state of the game or the state at the end of a specific round. If a user requests to see the state of the game at the end of a past round, they will be shown all cards possessed by each player in that round. However, when users query the current state of the game, they will not be shown any cards unless they provide a valid player UUID to authenticate themselves as a specific player. In that case, they will be shown the cards of that player.
+
+  Users can query the (current or past, as mentioned above) state of the game at any point. When they do so, they get the following information about the game:
+
+  * the nickname of the admin
+  * whether the game is public
+  * the room number, which will be displayed in the list of public games every time the game is made public
+  * the status of the game
+  * the round number (starting at 1 and incremented by 1 every time a round ends)
+  * the maximum number of cards permitted for a player
+  * the nicknames of the players who are still participating in the game at the given point, together with the number of cards that each of these players have
+  * the cards of the players. This field is either empty (for an ongoing round reported to an observer), filled with the cards of one player (for an ongoing round reported to an authenticated player) or filled with the cards of each player (for a finished round)
+  * the nickname of the player who is now supposed to make a move
+  * the rules
+  * the history of the events in the (current or past) round. An event is a player making a bet (of which there will be at least one but potentially many in a given round), a player checking another player (which will happen once by the end of the round) or a player losing a round (which will be recorded as the last event of that round).
+  * the deadline for the current player's move, if the game has a time limit
+  * the time the update is being sent over the API
 
 * **URL**
 
@@ -194,7 +295,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "a", "public": "false", "status": "Running", "round_number": 1, "max_cards": 11, "players": [{"nickname": "b", "n_cards": 1}, {"nickname": "a", "n_cards": 1}], "hands": [{"nickname": "a", "hand": [{"value": 5, "colour": 2}]}], "cp_nickname": "b", "history": []}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin"}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 
@@ -207,9 +308,9 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a
 ```
 
-**Play**
-  ----
-  Allows a user to make a move in a game. The `action_id` required is determined by the game's rules, specifically the `deck_size`.
+## Play
+
+  Allows a user to make a move in a game. The `action_id` required is determined by the game's rules, specifically the `deck_size`. The player provides their UUID for authentication.
 
 * **URL**
 
@@ -243,9 +344,9 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/play?player_uuid=a6a53849-44e9-4211-8a21-63c4a9a91d53&action_id=88
 ```
 
-**Make game public**
-  ----
-  Allows the first player who joined the game to make it public (visible to anyone).
+## Make game public
+
+  Allows the admin to make the game public. A public game is visible to any observer. A game starts private.
 
 * **URL**
 
@@ -282,9 +383,9 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/play?player_uuid=a6a53849
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-public?admin_uuid=a6a53849-44e9-4211-8a21-63c4a9a91d53
 ```
 
-**Make game private**
-  ----
-  Allows the first player who joined the game to make it private (visible to only those who know its UUID).
+## Make game private
+
+  Allows the admin to make the game private. A private game can only be seen by the users who have its UUID. A game starts private.
 
 * **URL**
 
@@ -321,8 +422,8 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-public?admin_uuid=a6
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-private?admin_uuid=a6a53849-44e9-4211-8a21-63c4a9a91d53
 ```
 
-**List public games**
-  ----
+## List public games
+
   Allows users to see all public games.
 
 * **URL**
@@ -352,8 +453,8 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-private?admin_uuid=a
 curl <HOST>/games
 ```
 
-**Send reaction**
-  ----
+## Send reaction
+
   Allows users to send reactions to specific games or to the public game lobby.
 
 * **URL**
@@ -394,11 +495,11 @@ curl <HOST>/games
 curl <HOST>/send-reaction?game_uuid=6f3e8308-1170-4b3d-87b9-b62916df330f&nickname=Rando&reaction=🤨
 ```
 
-## Action IDs
+# Action IDs
 
-Action IDs are determined dynamically based on the `deck_size` rule.
-* **24-Card Deck:** `action_id` ranges from 0 to 87 for bets. **88 is a check.**
-* **32-Card Deck:** `action_id` ranges from 0 to 139 for bets. **140 is a check.**
+Action IDs depend on the `deck_size` rule.
+* **24-Card Deck:** `action_id` ranges from 0 to 87 for bets. 88 is a check.
+* **32-Card Deck:** `action_id` ranges from 0 to 139 for bets. 140 is a check.
 
 A higher `action_id` represents betting on a more senior set.
 
@@ -639,3 +740,42 @@ For the 32-card deck:
 | 138       | Straight flush (10-A), hearts        |
 | 139       | Straight flush (10-A), spades        |
 | 140       | **Check**                            |
+
+# WebSocket API
+
+To receive real-time game state updates and reactions, clients can connect to the WebSocket API. This is the preferred way to keep the UI synchronized for all players and observers without constant polling.
+
+## Connection
+
+Establishes a persistent connection to the WebSocket server. To subscribe to a specific game's events, the `game_uuid` must be provided in the headers during the connection handshake.
+
+* **URL**
+
+    `wss://<WEBSOCKET_HOST>`
+
+* **Connection Headers**
+
+    **Required for game subscription:**
+
+    `"game_uuid"=string`
+
+    **Optional:**
+
+    `"player_uuid"=string` (To receive private data like your own hand)
+
+    `"reactions_enabled"=string` ("true" or "false", defaults to false)
+
+* **On a successful connection**, the server will accept the connection. Any subsequent updates for the subscribed game will be automatically pushed to the client. There is no specific message body on connection success.
+
+## Server-sent messages
+
+Once connected, the client will receive JSON payloads for game state changes or player reactions.
+
+* **Game state update:** The payload will be identical in structure to the response from the `Get game state` HTTP endpoint. This includes changes to the current player, history, hands (censored appropriately), and game status.
+
+* **Reaction update:** The payload will be a JSON object containing details about the reaction sent.
+    **Content:** `{"game_uuid": "...", "nickname": "Rando", "reaction": "👍", "nickname_authenticated": "true"}`
+
+## Disconnection
+
+When the client disconnects, the server automatically cleans up the connection and stops sending updates.

--- a/api/README.md
+++ b/api/README.md
@@ -2,15 +2,17 @@
 
 **Create game**
   ----
-  Creates an empty game object.
+  Creates an empty game object with default rules. Optionally, joins the newly created game.
 
 * **URL**
 
   /games/create
 
-* **Method:**
+* **Data Params**
 
-  `GET`
+  **Optional:**
+
+  `"nickname"=string`
 
 * **URL Params**
 
@@ -29,15 +31,11 @@ curl <HOST>/games/create
 
 **Join game**
   ----
-  Allows a player to join a specific game under a specific nickname.
+  Allows a player to join a specific game under a specific nickname. Joining a game will reset the 'ready' status of all human players.
 
 * **URL**
 
   /games/{game_uuid}/join
-
-* **Method:**
-
-  `GET`
 
 * **URL Params**
 
@@ -67,17 +65,85 @@ curl <HOST>/games/create
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat
 ```
 
-**Start game**
+**Set Readiness**
   ----
-  Allows the first player who joined the game to start it. After that point, no further players can join the game.
+  Allows a player to set their readiness state. If all players are ready and there are at least 2, the game will start automatically.
+
+* **URL**
+
+  /games/{game_uuid}/set-readiness
+
+* **URL Params**
+
+  **Required:**
+
+  `"game_uuid"=string`
+
+* **Data Params**
+
+   **Required:**
+
+   `"player_uuid"=string`
+   `"ready"=boolean`
+
+* **Success Response:**
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"Readiness updated"}` or `{"message":"All players ready. Game started."}`
+
+* **Sample Call:**
+
+```
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/set-readiness?player_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&ready=True
+```
+
+**Change Rules**
+  ----
+  Allows the game admin to change the rules of the game before it starts. Changing rules will reset the readiness of all human players.
+
+* **URL**
+
+  /games/{game_uuid}/change-rules
+
+* **URL Params**
+
+  **Required:**
+
+  `"game_uuid"=string`
+
+* **Data Params**
+
+   **Required:**
+
+   `"admin_uuid"=string`
+   `"rules"=object`
+
+* **Success Response:**
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"Rules updated"}`
+
+* **Rules Object Details:**
+    * `time_limit`: integer (0-300 seconds)
+    * `deck_size`: integer (24 or 32)
+    * `common_cards`: integer (0-12)
+    * `jokers`: integer (0-12)
+    * `blanks`: integer (0-12)
+    * `standard_order`: boolean
+
+* **Sample Call:**
+
+```
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&rules={"common_cards":4}
+```
+
+**Start game (Legacy)**
+  ----
+  Allows the first player who joined the game to start it. **This is a legacy endpoint.** The recommended way to start a game is for all players to set their readiness to `true`.
 
 * **URL**
 
   /games/{game_uuid}/start
-
-* **Method:**
-
-  `GET`
 
 * **URL Params**
 
@@ -113,10 +179,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 
   /games/{game_uuid}
 
-* **Method:**
-
-  `GET`
-
 * **URL Params**
 
   **Required:**
@@ -128,7 +190,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
   **Optional:**
 
   `"player_uuid"=string`
-
   `"round"=integer`
 
 * **Success Response:**
@@ -149,15 +210,11 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a
 
 **Play**
   ----
-  Allows a user to make a move in a game. See below for explanation of the `action_id` parameter.
+  Allows a user to make a move in a game. The `action_id` required is determined by the game's rules, specifically the `deck_size`.
 
 * **URL**
 
   /games/{game_uuid}/play
-
-* **Method:**
-
-  `GET`
 
 * **URL Params**
 
@@ -170,7 +227,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a
   **Required:**
 
   `"player_uuid"=string`
-
   `"action_id"=integer`
 
 * **Success Response:**
@@ -195,10 +251,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/play?player_uuid=a6a53849
 * **URL**
 
   /games/{game_uuid}/make-public
-
-* **Method:**
-
-  `GET`
 
 * **URL Params**
 
@@ -239,10 +291,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-public?admin_uuid=a6
 
   /games/{game_uuid}/make-private
 
-* **Method:**
-
-  `GET`
-
 * **URL Params**
 
   **Required:**
@@ -282,10 +330,6 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/make-private?admin_uuid=a
 
   /games
 
-* **Method:**
-
-  `GET`
-
 * **URL Params**
 
   NONE
@@ -316,10 +360,6 @@ curl <HOST>/games
 * **URL**
 
   /send-reaction
-
-* **Method:**
-
-  `GET`
 
 * **URL Params**
 
@@ -357,7 +397,11 @@ curl <HOST>/send-reaction?game_uuid=6f3e8308-1170-4b3d-87b9-b62916df330f&nicknam
 
 ## Action IDs
 
-The table below details what action ID a player should use to make a specific move. Action IDs between 0 and 87 cover bets, while 88 is a check. The way the actions are arranged, a set with a higher action ID is more senior than one with a lower action ID. Therefore, an action with ID `k` can only be followed by an action with an ID higher than `k`.
+Action IDs are determined dynamically based on the `deck_size` rule.
+* **24-Card Deck:** `action_id` ranges from 0 to 87 for bets. **88 is a check.**
+* **32-Card Deck:** `action_id` ranges from 0 to 139 for bets. **140 is a check.**
+
+The seniority of bets is calculated programmatically. A higher `action_id` represents betting on a more senior set. However, if the betting order is reversed, players can only bet on less senior sets (or check, if applicable).
 
 | Action ID | Set description                      |
 |-----------|--------------------------------------|
@@ -450,3 +494,149 @@ The table below details what action ID a player should use to make a specific mo
 | 86        | Great straight flush (9-A), hearts   |
 | 87        | Great straight flush (9-A), spades   |
 | 88        | **Check**                            |
+
+For the 32-card deck:
+
+| Action ID | Set description                      |
+|-----------|--------------------------------------|
+| 0         | High card, 7                         |
+| 1         | High card, 8                         |
+| 2         | High card, 9                         |
+| 3         | High card, 10                        |
+| 4         | High card, J                         |
+| 5         | High card, Q                         |
+| 6         | High card, K                         |
+| 7         | High card, A                         |
+| 8         | Pair of 7s                           |
+| 9         | Pair of 8s                           |
+| 10        | Pair of 9s                           |
+| 11        | Pair of 10s                          |
+| 12        | Pair of Js                           |
+| 13        | Pair of Qs                           |
+| 14        | Pair of Ks                           |
+| 15        | Pair of As                           |
+| 16        | Two pair, 8s and 7s                  |
+| 17        | Two pair, 9s and 7s                  |
+| 18        | Two pair, 9s and 8s                  |
+| 19        | Two pair, 10s and 7s                 |
+| 20        | Two pair, 10s and 8s                 |
+| 21        | Two pair, 10s and 9s                 |
+| 22        | Two pair, Js and 7s                  |
+| 23        | Two pair, Js and 8s                  |
+| 24        | Two pair, Js and 9s                  |
+| 25        | Two pair, Js and 10s                 |
+| 26        | Two pair, Qs and 7s                  |
+| 27        | Two pair, Qs and 8s                  |
+| 28        | Two pair, Qs and 9s                  |
+| 29        | Two pair, Qs and 10s                 |
+| 30        | Two pair, Qs and Js                  |
+| 31        | Two pair, Ks and 7s                  |
+| 32        | Two pair, Ks and 8s                  |
+| 33        | Two pair, Ks and 9s                  |
+| 34        | Two pair, Ks and 10s                 |
+| 35        | Two pair, Ks and Js                  |
+| 36        | Two pair, Ks and Qs                  |
+| 37        | Two pair, As and 7s                  |
+| 38        | Two pair, As and 8s                  |
+| 39        | Two pair, As and 9s                  |
+| 40        | Two pair, As and 10s                 |
+| 41        | Two pair, As and Js                  |
+| 42        | Two pair, As and Qs                  |
+| 43        | Two pair, As and Ks                  |
+| 44        | Straight (7-J)                       |
+| 45        | Straight (8-Q)                       |
+| 46        | Straight (9-K)                       |
+| 47        | Straight (10-A)                      |
+| 48        | Three of a kind, 7s                  |
+| 49        | Three of a kind, 8s                  |
+| 50        | Three of a kind, 9s                  |
+| 51        | Three of a kind, 10s                 |
+| 52        | Three of a kind, Js                  |
+| 53        | Three of a kind, Qs                  |
+| 54        | Three of a kind, Ks                  |
+| 55        | Three of a kind, As                  |
+| 56        | Full house, 7s over 8s               |
+| 57        | Full house, 7s over 9s               |
+| 58        | Full house, 7s over 10s              |
+| 59        | Full house, 7s over Js               |
+| 60        | Full house, 7s over Qs               |
+| 61        | Full house, 7s over Ks               |
+| 62        | Full house, 7s over As               |
+| 63        | Full house, 8s over 7s               |
+| 64        | Full house, 8s over 9s               |
+| 65        | Full house, 8s over 10s              |
+| 66        | Full house, 8s over Js               |
+| 67        | Full house, 8s over Qs               |
+| 68        | Full house, 8s over Ks               |
+| 69        | Full house, 8s over As               |
+| 70        | Full house, 9s over 7s               |
+| 71        | Full house, 9s over 8s               |
+| 72        | Full house, 9s over 10s              |
+| 73        | Full house, 9s over Js               |
+| 74        | Full house, 9s over Qs               |
+| 75        | Full house, 9s over Ks               |
+| 76        | Full house, 9s over As               |
+| 77        | Full house, 10s over 7s              |
+| 78        | Full house, 10s over 8s              |
+| 79        | Full house, 10s over 9s              |
+| 80        | Full house, 10s over Js              |
+| 81        | Full house, 10s over Qs              |
+| 82        | Full house, 10s over Ks              |
+| 83        | Full house, 10s over As              |
+| 84        | Full house, Js over 7s               |
+| 85        | Full house, Js over 8s               |
+| 86        | Full house, Js over 9s               |
+| 87        | Full house, Js over 10s              |
+| 88        | Full house, Js over Qs               |
+| 89        | Full house, Js over Ks               |
+| 90        | Full house, Js over As               |
+| 91        | Full house, Qs over 7s               |
+| 92        | Full house, Qs over 8s               |
+| 93        | Full house, Qs over 9s               |
+| 94        | Full house, Qs over 10s              |
+| 95        | Full house, Qs over Js               |
+| 96        | Full house, Qs over Ks               |
+| 97        | Full house, Qs over As               |
+| 98        | Full house, Ks over 7s               |
+| 99        | Full house, Ks over 8s               |
+| 100       | Full house, Ks over 9s               |
+| 101       | Full house, Ks over 10s              |
+| 102       | Full house, Ks over Js               |
+| 103       | Full house, Ks over Qs               |
+| 104       | Full house, Ks over As               |
+| 105       | Full house, As over 7s               |
+| 106       | Full house, As over 8s               |
+| 107       | Full house, As over 9s               |
+| 108       | Full house, As over 10s              |
+| 109       | Full house, As over Js               |
+| 110       | Full house, As over Qs               |
+| 111       | Full house, As over Ks               |
+| 112       | Flush, clubs                         |
+| 113       | Flush, diamonds                      |
+| 114       | Flush, hearts                        |
+| 115       | Flush, spades                        |
+| 116       | Four of a kind, 7s                   |
+| 117       | Four of a kind, 8s                   |
+| 118       | Four of a kind, 9s                   |
+| 119       | Four of a kind, 10s                  |
+| 120       | Four of a kind, Js                   |
+| 121       | Four of a kind, Qs                   |
+| 122       | Four of a kind, Ks                   |
+| 123       | Four of a kind, As                   |
+| 124       | Straight flush (7-J), clubs          |
+| 125       | Straight flush (7-J), diamonds       |
+| 126       | Straight flush (7-J), hearts         |
+| 127       | Straight flush (7-J), spades         |
+| 128       | Straight flush (8-Q), clubs          |
+| 129       | Straight flush (8-Q), diamonds       |
+| 130       | Straight flush (8-Q), hearts         |
+| 131       | Straight flush (8-Q), spades         |
+| 132       | Straight flush (9-K), clubs          |
+| 133       | Straight flush (9-K), diamonds       |
+| 134       | Straight flush (9-K), hearts         |
+| 135       | Straight flush (9-K), spades         |
+| 136       | Straight flush (10-A), clubs         |
+| 137       | Straight flush (10-A), diamonds      |
+| 138       | Straight flush (10-A), hearts        |
+| 139       | Straight flush (10-A), spades        |
+| 140       | **Check**                            |

--- a/api/ai/aiagent.py
+++ b/api/ai/aiagent.py
@@ -5,16 +5,11 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-
 lambda_client = boto3.client('lambda')
 
-
 def parse_event(event):
-    # Basic input validation
     if not isinstance(event, dict):
         return False
-
-    # Handle both direct triggers and API Gateway
     body = event.get("body", event)
     if isinstance(body, str):
         try:
@@ -27,26 +22,38 @@ def parse_event(event):
     body.update(query_params)
     return body
 
-
 def get_player_by_nickname(players, nickname):
-    filtered_players = [p for p in players if p["nickname"] == nickname]
-    if filtered_players:
-        return filtered_players[0]
-
+    return next((p for p in players if p["nickname"] == nickname), None)
 
 def get_aiagent_player_uuid(game):
-    current_player = game["cp_nickname"]
-    player_obj = get_player_by_nickname(game["players"], current_player)
-    return player_obj.get("uuid")
+    current_player = game.get("cp_nickname")
+    if not current_player:
+        return None
+    player_obj = get_player_by_nickname(game.get("players", []), current_player)
+    return player_obj.get("uuid") if player_obj else None
 
+def is_legal(action, game):
+    """
+    Checks if an action is legal based on the current game state and rules.
+    """
+    rules = game.get("rules", {})
+    deck_size = rules.get("deck_size", 24)
+    check_action_id = 140 if deck_size == 32 else 88
+    
+    if not (0 <= action <= check_action_id):
+        return False
+        
+    history = game.get("history", [])
+    
+    if not history and action == check_action_id:
+        return False
+        
+    if history and action < check_action_id:
+        last_action_id = history[-1].get("action_id", -1)
+        if action <= last_action_id:
+            return False
 
-def is_legal(action, history):
-    if action not in range(89):
-        return False
-    if not history and action == 88 or history and action <= history[-1]["action_id"]:
-        return False
     return True
-
 
 def call_play(action, aiagent_player_uuid, game_uuid):
     """
@@ -63,8 +70,7 @@ def call_play(action, aiagent_player_uuid, game_uuid):
         FunctionName='blef-play',
         InvocationType='Event',
         Payload=json.dumps(payload)
-        )
-
+    )
 
 def lambda_handler(event, context):
     logger.info('## EVENT')
@@ -80,7 +86,7 @@ def lambda_handler(event, context):
     action = agent.determine_action(game)
     logger.info('## ACTION')
     logger.info(action)
-    assert is_legal(action, game["history"])
+    assert is_legal(action, game)
 
     call_play(action, aiagent_player_uuid, game["game_uuid"])
     message = "Action made"

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -4,6 +4,7 @@ from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.game import unset_human_readiness
 from shared.api_gateway import parse_event
+from shared.game import update_ai_readiness
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
@@ -93,6 +94,8 @@ def lambda_handler(event, context):
             # Apply the validated rule
             rules[rule] = value
         
+        players = update_ai_readiness(players, rules)
+
         # If time limit is on right now, have every human re-confirm readiness 
         if rules.get("time_limit", 0) > 0:
             players = unset_human_readiness(players)

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -8,23 +8,24 @@ from shared.game import update_ai_readiness
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
-def update_in_dynamodb(game_uuid, rules, players):
-    # # Unset readiness for all human players after any rule change - for now we only do it if time limit is on
-    # players = unset_human_readiness(players)
+def update_in_dynamodb(game_uuid, rules, players, max_cards_update=None):
+    update_expressions = ["#rules = :rules", "players = :players", "last_modified = :last_modified"]
+    expression_attribute_names = {'#rules': 'rules'}
+    expression_attribute_values = {
+        ':rules': rules,
+        ':players': players,
+        ':last_modified': decimal.Decimal(str(time.time()))
+    }
+
+    if max_cards_update is not None:
+        update_expressions.append("max_cards = :max_cards")
+        expression_attribute_values[':max_cards'] = max_cards_update
 
     table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set #rules = :rules, players = :players, last_modified = :last_modified",
-        ExpressionAttributeNames={
-            '#rules': 'rules'
-        },
-        ExpressionAttributeValues={
-            ':rules': rules,
-            ':players': players,
-            ':last_modified': decimal.Decimal(str(time.time()))
-        },
+        Key={'game_uuid': game_uuid},
+        UpdateExpression="set " + ", ".join(update_expressions),
+        ExpressionAttributeNames=expression_attribute_names,
+        ExpressionAttributeValues=expression_attribute_values,
         ReturnValues="NONE"
     )
     return True
@@ -56,46 +57,46 @@ def lambda_handler(event, context):
             return parameter_error_payload("admin_uuid", admin_uuid, message="Admin UUID does not match")
 
         rules = game.get("rules", {})
-        
-        # Iterate through all query parameters to find and apply rule changes
-        for rule, value in body.items():
-            # Skip non-rule parameters
-            if rule not in rules:
-                continue
+        max_cards_update = None
 
-            # Type conversion for numeric rules
-            if rule in ["time_limit", "deck_size", "common_cards", "jokers", "blanks"]:
+        # Iterate through all query parameters to find and apply changes
+        for key, value in body.items():
+            # Type conversion - right now all rules are integers
+            if key in ["time_limit", "deck_size", "common_cards", "jokers", "blanks", "max_cards"]:
                 try:
                     value = int(value)
                 except (ValueError, TypeError):
-                     return parameter_error_payload(rule, value, "Rule must be an integer.")
+                     return parameter_error_payload(key, value, "Rule must be an integer.")
 
-            # Validation logic
-            if rule == "time_limit":
+            if key == "time_limit":
                 if not (0 <= value <= 300):
-                    return parameter_error_payload(rule, value, "Time limit must be an integer between 0 and 300")
-            elif rule == "deck_size":
+                    return parameter_error_payload(key, value, "Time limit must be an integer between 0 and 300")
+                rules[key] = value
+            elif key == "deck_size":
                 if value not in [24, 32]:
-                    return parameter_error_payload(rule, value, "Deck size must be 24 or 32")
-            elif rule == "common_cards":
+                    return parameter_error_payload(key, value, "Deck size must be 24 or 32")
+                rules[key] = value
+            elif key == "common_cards":
                 if not (-2 <= value <= 12):
-                    return parameter_error_payload(rule, value, "Common cards must be an integer between 0 and 12")
-            elif rule in ["jokers", "blanks"]:
+                    return parameter_error_payload(key, value, "Common cards must be an integer between 0 and 12")
+                rules[key] = value
+            elif key in ["jokers", "blanks"]:
                 if not (0 <= value <= 12):
-                    return parameter_error_payload(rule, value, "Jokers and blanks must be an integer between 0 and 12")
-            
-            # Apply the validated rule
-            rules[rule] = value
-        
+                    return parameter_error_payload(key, value, "Jokers and blanks must be an integer between 0 and 12")
+                rules[key] = value
+            elif key == "max_cards":
+                if not (0 <= value <= 11):
+                    return parameter_error_payload(key, value, "Max cards must be 0 (for auto) or an integer between 1 and 11")
+                max_cards_update = value
+
         players = update_ai_readiness(players, rules)
 
-        # If time limit is on right now, have every human re-confirm readiness 
         if rules.get("time_limit", 0) > 0:
             players = unset_human_readiness(players)
 
-        logger.info('## NEW RULES')
-        logger.info(rules)
-        update_in_dynamodb(game_uuid, rules, players)
+        logger.info(f'## NEW RULES: {rules}')
+        logger.info(f'## MAX CARDS UPDATE: {max_cards_update}')
+        update_in_dynamodb(game_uuid, rules, players, max_cards_update)
 
         return response_payload(200, {"message": "Rules updated"})
 

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -85,7 +85,10 @@ def lambda_handler(event, context):
             elif key == "max_cards":
                 if not (0 <= value <= 11):
                     return parameter_error_payload(key, value, "Max cards must be 0 (for no preference) or an integer between 1 and 11")
-                rules["max_cards_preference"] = value
+                if value == 0:
+                    rules["max_cards_preference"] = None
+                else:
+                    rules["max_cards_preference"] = value
 
         if rules.get("time_limit", 0) > 0:
             players = unset_human_readiness(players)

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -78,7 +78,7 @@ def lambda_handler(event, context):
                 if value not in [24, 32]:
                     return parameter_error_payload(rule, value, "Deck size must be 24 or 32")
             elif rule == "common_cards":
-                if not (-1 <= value <= 12):
+                if not (-2 <= value <= 12):
                     return parameter_error_payload(rule, value, "Common cards must be an integer between 0 and 12")
             elif rule in ["jokers", "blanks"]:
                 if not (0 <= value <= 12):

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -2,12 +2,16 @@ import time
 import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
+from shared.constants import GameStatus, RuleValues, CommonCardsRules
 from shared.game import unset_human_readiness, calculate_actual_max_cards
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
 def update_in_dynamodb(game_uuid, rules, players, max_cards=None):
+    """
+    Updates the game rules, player readiness, and max cards in DynamoDB.
+    """
     update_expressions = ["#rules = :rules", "players = :players", "last_modified = :last_modified"]
     expression_attribute_names = {'#rules': 'rules'}
     expression_attribute_values = {
@@ -43,7 +47,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Cannot change rules after the game has started")
 
         admin_uuid = str(body.get("admin_uuid"))
@@ -57,40 +61,46 @@ def lambda_handler(event, context):
 
         rules = game.get("rules", {})
 
-        # Iterate through all query parameters to find and apply changes
         for key, value in body.items():
-            # Type conversion - right now all rules are integers
             if key in ["time_limit", "deck_size", "common_cards", "jokers", "blanks", "max_cards"]:
                 try:
                     value = int(value)
                 except (ValueError, TypeError):
-                     return parameter_error_payload(key, value, "Rule must be an integer.")
+                     return parameter_error_payload(key, value, "Every rule must be an integer.")
 
             if key == "time_limit":
-                if not (0 <= value <= 300):
-                    return parameter_error_payload(key, value, "Time limit must be an integer between 0 and 300")
+                if not RuleValues.is_valid_time_limit_rule(value):
+                    return parameter_error_payload(key, value, 
+                        f"Time limit must be {RuleValues.TIME_LIMIT_NO_LIMIT} (for no limit) or an integer between "
+                        f"{RuleValues.TIME_LIMIT_RANGE.BOTTOM} and {RuleValues.TIME_LIMIT_RANGE.TOP}")
                 rules[key] = value
             elif key == "deck_size":
-                if value not in [24, 32]:
-                    return parameter_error_payload(key, value, "Deck size must be 24 or 32")
+                if value not in RuleValues.DECK_SIZES:
+                    return parameter_error_payload(key, value, f"Deck size must be one of {RuleValues.DECK_SIZES}")
                 rules[key] = value
             elif key == "common_cards":
-                if not (-2 <= value <= 12):
-                    return parameter_error_payload(key, value, "Common cards must be an integer between 0 and 12")
+                if not RuleValues.is_valid_common_cards_rule(value):
+                    return parameter_error_payload(key, value,
+                        f"Common cards must be between {RuleValues.COMMON_CARDS_FIXED_RANGE.BOTTOM} and "
+                        f"{RuleValues.COMMON_CARDS_FIXED_RANGE.TOP}, or one of the special values: "
+                        f"{CommonCardsRules.special_values()}")
                 rules[key] = value
-            elif key in ["jokers", "blanks"]:
-                if not (0 <= value <= 12):
-                    return parameter_error_payload(key, value, "Jokers and blanks must be an integer between 0 and 12")
+            elif key == "jokers":
+                if not (RuleValues.JOKERS_RANGE.BOTTOM <= value <= RuleValues.JOKERS_RANGE.TOP):
+                    return parameter_error_payload(key, value, f"Jokers must be an integer between {RuleValues.JOKERS_RANGE.BOTTOM} and {RuleValues.JOKERS_RANGE.TOP}")
+                rules[key] = value
+            elif key == "blanks":
+                if not (RuleValues.BLANKS_RANGE.BOTTOM <= value <= RuleValues.BLANKS_RANGE.TOP):
+                    return parameter_error_payload(key, value, f"Blanks must be an integer between {RuleValues.BLANKS_RANGE.BOTTOM} and {RuleValues.BLANKS_RANGE.TOP}")
                 rules[key] = value
             elif key == "max_cards":
-                if not (0 <= value <= 11):
-                    return parameter_error_payload(key, value, "Max cards must be 0 (for no preference) or an integer between 1 and 11")
-                if value == 0:
-                    rules["max_cards_preference"] = None
-                else:
-                    rules["max_cards_preference"] = value
+                if not RuleValues.is_valid_max_cards_rule(value):
+                    return parameter_error_payload(key, value,
+                        f"Max cards must be {RuleValues.MAX_CARDS_NO_PREFERENCE_API} (for no preference) or an integer between "
+                        f"{RuleValues.MAX_CARDS_FIXED_RANGE.BOTTOM} and {RuleValues.MAX_CARDS_FIXED_RANGE.TOP}")
+                rules["max_cards_preference"] = value if value != RuleValues.MAX_CARDS_NO_PREFERENCE_API else RuleValues.MAX_CARDS_NO_PREFERENCE_INTERNAL
 
-        if rules.get("time_limit", 0) > 0:
+        if rules.get("time_limit", RuleValues.TIME_LIMIT_NO_LIMIT) != RuleValues.TIME_LIMIT_NO_LIMIT:
             players = unset_human_readiness(players)
 
         max_cards = calculate_actual_max_cards(rules, len(players))

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -2,12 +2,12 @@ import time
 import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
-from shared.game import unset_human_readiness
+from shared.game import unset_human_readiness, calculate_actual_max_cards
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
-def update_in_dynamodb(game_uuid, rules, players, max_cards_update=None):
+def update_in_dynamodb(game_uuid, rules, players, max_cards=None):
     update_expressions = ["#rules = :rules", "players = :players", "last_modified = :last_modified"]
     expression_attribute_names = {'#rules': 'rules'}
     expression_attribute_values = {
@@ -16,9 +16,9 @@ def update_in_dynamodb(game_uuid, rules, players, max_cards_update=None):
         ':last_modified': decimal.Decimal(str(time.time()))
     }
 
-    if max_cards_update is not None:
+    if max_cards is not None:
         update_expressions.append("max_cards = :max_cards")
-        expression_attribute_values[':max_cards'] = max_cards_update
+        expression_attribute_values[':max_cards'] = max_cards
 
     table.update_item(
         Key={'game_uuid': game_uuid},
@@ -56,7 +56,6 @@ def lambda_handler(event, context):
             return parameter_error_payload("admin_uuid", admin_uuid, message="Admin UUID does not match")
 
         rules = game.get("rules", {})
-        max_cards_update = None
 
         # Iterate through all query parameters to find and apply changes
         for key, value in body.items():
@@ -85,15 +84,19 @@ def lambda_handler(event, context):
                 rules[key] = value
             elif key == "max_cards":
                 if not (0 <= value <= 11):
-                    return parameter_error_payload(key, value, "Max cards must be 0 (for auto) or an integer between 1 and 11")
-                max_cards_update = value
+                    return parameter_error_payload(key, value, "Max cards must be 0 (for no preference) or an integer between 1 and 11")
+                if value == 0:
+                    rules["max_cards_preference"] = None
+                rules["max_cards_preference"] = value
 
         if rules.get("time_limit", 0) > 0:
             players = unset_human_readiness(players)
 
+        max_cards = calculate_actual_max_cards(rules, len(players))
+
         logger.info(f'## NEW RULES: {rules}')
-        logger.info(f'## MAX CARDS UPDATE: {max_cards_update}')
-        update_in_dynamodb(game_uuid, rules, players, max_cards_update)
+        logger.info(f'## MAX CARDS: {max_cards}')
+        update_in_dynamodb(game_uuid, rules, players, max_cards)
 
         return response_payload(200, {"message": "Rules updated"})
 

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -1,0 +1,107 @@
+import time
+import decimal
+from shared.response import *
+from shared.db import table, get_from_dynamodb
+from shared.game import unset_human_readiness
+from shared.api_gateway import parse_event
+from shared.inputs import is_valid_uuid
+from shared.logging import logger
+
+def update_in_dynamodb(game_uuid, rules, players):
+    # # Unset readiness for all human players after any rule change - for now we only do it if time limit is on
+    # players = unset_human_readiness(players)
+
+    table.update_item(
+        Key={
+            'game_uuid': game_uuid
+        },
+        UpdateExpression="set #rules = :rules, players = :players, last_modified = :last_modified",
+        ExpressionAttributeNames={
+            '#rules': 'rules'
+        },
+        ExpressionAttributeValues={
+            ':rules': rules,
+            ':players': players,
+            ':last_modified': decimal.Decimal(str(time.time()))
+        },
+        ReturnValues="NONE"
+    )
+    return True
+
+def lambda_handler(event, context):
+    try:
+        body = parse_event(event)
+        if not body:
+            return request_error_payload(event)
+
+        game_uuid = str(body.get("game_uuid"))
+        if not is_valid_uuid(game_uuid):
+            return parameter_error_payload("game_uuid", game_uuid, message="Invalid game UUID")
+
+        game = get_from_dynamodb(game_uuid)
+        if not game:
+            return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
+
+        if game.get("status") != "Not started":
+            return error_payload(403, "Cannot change rules after the game has started")
+
+        admin_uuid = str(body.get("admin_uuid"))
+        if not is_valid_uuid(admin_uuid):
+            return parameter_error_payload("admin_uuid", admin_uuid, message="Invalid admin UUID")
+
+        players = game.get("players")
+        game_admin_uuid = [player["uuid"] for player in players if player["nickname"] == game.get("admin_nickname")][0]
+        if game_admin_uuid != admin_uuid:
+            return parameter_error_payload("admin_uuid", admin_uuid, message="Admin UUID does not match")
+
+        rules = game.get("rules", {})
+        
+        # Iterate through all query parameters to find and apply rule changes
+        for rule, value in body.items():
+            # Skip non-rule parameters
+            if rule not in rules:
+                continue
+
+            # Type conversion for numeric and boolean rules
+            if rule in ["time_limit", "deck_size", "common_cards", "jokers", "blanks"]:
+                try:
+                    value = int(value)
+                except (ValueError, TypeError):
+                     return parameter_error_payload(rule, value, "Rule must be an integer.")
+            elif rule == "standard_order":
+                if value == 'True':
+                    value = True
+                elif value == 'False':
+                    value = False
+                else:
+                    return parameter_error_payload(rule, value, "Standard order must be a boolean string ('True' or 'False').")
+
+            # Validation logic
+            if rule == "time_limit":
+                if not (0 <= value <= 300):
+                    return parameter_error_payload(rule, value, "Time limit must be an integer between 0 and 300")
+            elif rule == "deck_size":
+                if value not in [24, 32]:
+                    return parameter_error_payload(rule, value, "Deck size must be 24 or 32")
+            elif rule == "common_cards":
+                if not (-1 <= value <= 12):
+                    return parameter_error_payload(rule, value, "Common cards must be an integer between 0 and 12")
+            elif rule in ["jokers", "blanks"]:
+                if not (0 <= value <= 12):
+                    return parameter_error_payload(rule, value, "Jokers and blanks must be an integer between 0 and 12")
+            
+            # Apply the validated rule
+            rules[rule] = value
+        
+        # If time limit is on right now, have every human re-confirm readiness 
+        if rules.get("time_limit", 0) > 0:
+            players = unset_human_readiness(players)
+
+        logger.info('## NEW RULES')
+        logger.info(rules)
+        update_in_dynamodb(game_uuid, rules, players)
+
+        return response_payload(200, {"message": "Rules updated"})
+
+    except Exception as err:
+        return internal_error_payload(err)

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -85,8 +85,6 @@ def lambda_handler(event, context):
             elif key == "max_cards":
                 if not (0 <= value <= 11):
                     return parameter_error_payload(key, value, "Max cards must be 0 (for no preference) or an integer between 1 and 11")
-                if value == 0:
-                    rules["max_cards_preference"] = None
                 rules["max_cards_preference"] = value
 
         if rules.get("time_limit", 0) > 0:

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -63,19 +63,12 @@ def lambda_handler(event, context):
             if rule not in rules:
                 continue
 
-            # Type conversion for numeric and boolean rules
+            # Type conversion for numeric rules
             if rule in ["time_limit", "deck_size", "common_cards", "jokers", "blanks"]:
                 try:
                     value = int(value)
                 except (ValueError, TypeError):
                      return parameter_error_payload(rule, value, "Rule must be an integer.")
-            elif rule == "standard_order":
-                if value == 'True':
-                    value = True
-                elif value == 'False':
-                    value = False
-                else:
-                    return parameter_error_payload(rule, value, "Standard order must be a boolean string ('True' or 'False').")
 
             # Validation logic
             if rule == "time_limit":

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -4,7 +4,6 @@ from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.game import unset_human_readiness
 from shared.api_gateway import parse_event
-from shared.game import update_ai_readiness
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
@@ -88,8 +87,6 @@ def lambda_handler(event, context):
                 if not (0 <= value <= 11):
                     return parameter_error_payload(key, value, "Max cards must be 0 (for auto) or an integer between 1 and 11")
                 max_cards_update = value
-
-        players = update_ai_readiness(players, rules)
 
         if rules.get("time_limit", 0) > 0:
             players = unset_human_readiness(players)

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
                 "common_cards": 0,
                 "jokers": 0,
                 "blanks": 0,
-                "max_cards_preference": None
+                "max_cards_preference": 0
             }
         }
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -1,7 +1,7 @@
 import uuid
 import random
 import re
-from shared.response import * 
+from shared.response import *
 from shared.db import save_in_dynamodb
 from shared.api_gateway import parse_event
 
@@ -24,7 +24,15 @@ def lambda_handler(event, context):
             "players": [],
             "hands": [],
             "cp_nickname": None,
-            "history": []
+            "history": [],
+            "rules": {
+                "time_limit": 0,
+                "deck_size": 24,
+                "common_cards": 0,
+                "jokers": 0,
+                "blanks": 0,
+                "standard_order": True
+            }
         }
 
         nickname = body.get("nickname")
@@ -36,7 +44,7 @@ def lambda_handler(event, context):
         if not re.match("^[a-zA-Z]\w*$", nickname):
             return parameter_error_payload("nickname", nickname, message="Nickname must start with a letter and only contain alphanumeric characters")
         player_uuid = str(uuid.uuid4())
-        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0}
+        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False}
         game.update({"players": [player], "admin_nickname": nickname})
         if save_in_dynamodb(game):
             return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player_uuid})

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -30,8 +30,7 @@ def lambda_handler(event, context):
                 "deck_size": 24,
                 "common_cards": 0,
                 "jokers": 0,
-                "blanks": 0,
-                "standard_order": True
+                "blanks": 0
             }
         }
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -4,6 +4,7 @@ import re
 from shared.response import *
 from shared.constants import GameStatus, RuleValues
 from shared.db import save_in_dynamodb
+from shared.game import create_player
 from shared.api_gateway import parse_event
 
 
@@ -45,11 +46,10 @@ def lambda_handler(event, context):
             return parameter_error_payload("nickname", nickname, message="Nickname invalid")
         if not re.match("^[a-zA-Z]\w*$", nickname):
             return parameter_error_payload("nickname", nickname, message="Nickname must start with a letter and only contain alphanumeric characters")
-        player_uuid = str(uuid.uuid4())
-        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False}
-        game.update({"players": [player], "admin_nickname": nickname})
+        player = create_player(game, nickname)
+        game.update({"players": [player], "admin_nickname": player.get("nickname")})
         if save_in_dynamodb(game):
-            return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player_uuid})
+            return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player.get("uuid")})
 
         raise(Exception("Something went wrong - ended up with no response"))
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
                 "common_cards": 0,
                 "jokers": 0,
                 "blanks": 0,
-                "max_cards_preference": 0
+                "max_cards_preference": None
             }
         }
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -2,6 +2,7 @@ import uuid
 import random
 import re
 from shared.response import *
+from shared.constants import GameStatus, RuleValues
 from shared.db import save_in_dynamodb
 from shared.api_gateway import parse_event
 
@@ -18,7 +19,7 @@ def lambda_handler(event, context):
             "admin_nickname": None,
             "public": "false",
             "room": random.randrange(10, 100),
-            "status": "Not started",
+            "status": GameStatus.NOT_STARTED,
             "round_number": 0,
             "max_cards": 0,
             "players": [],
@@ -26,12 +27,12 @@ def lambda_handler(event, context):
             "cp_nickname": None,
             "history": [],
             "rules": {
-                "time_limit": 0,
-                "deck_size": 24,
-                "common_cards": 0,
-                "jokers": 0,
-                "blanks": 0,
-                "max_cards_preference": None
+                "time_limit": RuleValues.TIME_LIMIT_DEFAULT,
+                "deck_size": RuleValues.DECK_SIZE_DEFAULT,
+                "common_cards": RuleValues.COMMON_CARDS_DEFAULT,
+                "jokers": RuleValues.JOKERS_DEFAULT,
+                "blanks": RuleValues.BLANKS_DEFAULT,
+                "max_cards_preference": RuleValues.MAX_CARDS_PREFERENCE_DEFAULT
             }
         }
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -30,7 +30,8 @@ def lambda_handler(event, context):
                 "deck_size": 24,
                 "common_cards": 0,
                 "jokers": 0,
-                "blanks": 0
+                "blanks": 0,
+                "max_cards_preference": None
             }
         }
 
@@ -38,6 +39,7 @@ def lambda_handler(event, context):
         if not nickname and save_in_dynamodb(game):
                 return response_payload(200, {"game_uuid": game_uuid})
 
+        # If the user wants to join at the same time
         if not isinstance(nickname, str):
             return parameter_error_payload("nickname", nickname, message="Nickname invalid")
         if not re.match("^[a-zA-Z]\w*$", nickname):

--- a/api/get_game.py
+++ b/api/get_game.py
@@ -53,7 +53,7 @@ def lambda_handler(event, context):
             if not player_nickname:
                 return parameter_error_payload("player_uuid", player_uuid, message="The UUID does not match any active player")
 
-        visible_game = censor_game(game, round_param, player_nickname)
+        visible_game = censor_game(game, player_nickname)
 
         return response_payload(200, visible_game)
 

--- a/api/get_game.py
+++ b/api/get_game.py
@@ -1,6 +1,7 @@
 from shared.response import *
 from shared.db import get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.game import get_nickname_by_uuid, censor_game
 from shared.inputs import is_valid_uuid
 
@@ -42,7 +43,7 @@ def lambda_handler(event, context):
         if round_param and current_round < round_param:
             return parameter_error_payload("round", round_param, message="The game has not reached this round")
 
-        if round_param and (round_param != current_round or current_status != "Running"):
+        if round_param and (round_param != current_round or current_status != GameStatus.RUNNING):
             game = get_from_dynamodb(f"{game_uuid}_{round_param}")
         else:
             round_param = current_round

--- a/api/get_game.py
+++ b/api/get_game.py
@@ -1,28 +1,8 @@
-import time
-import decimal
-from shared.response import * 
-from shared.db import table, get_from_dynamodb
+from shared.response import *
+from shared.db import get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.game import get_nickname_by_uuid, get_revealed_hands
 from shared.inputs import is_valid_uuid
-
-
-def update_in_dynamodb(game_uuid, public):
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set last_modified = :last_modified, #game_public = :public",
-        ExpressionAttributeValues={
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':public': public
-        },
-        ExpressionAttributeNames={
-            '#game_public': "public"
-        },
-        ReturnValues="NONE"
-    )
-    return True
 
 
 def lambda_handler(event, context):
@@ -91,9 +71,11 @@ def lambda_handler(event, context):
             "max_cards": game["max_cards"],
             "players": private_players,
             "hands": revealed_hands,
+            "common_hand": game.get("common_hand", []),
             "cp_nickname": game["cp_nickname"],
             "history": game["history"],
-            "last_modified": game["last_modified"]
+            "last_modified": game["last_modified"],
+            "rules": game.get("rules", {})
         }
 
         return response_payload(200, visible_game)

--- a/api/get_game.py
+++ b/api/get_game.py
@@ -47,16 +47,13 @@ def lambda_handler(event, context):
         else:
             round_param = current_round
 
+        player_nickname = None
         if player_uuid:
             player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-            player_authenticated = bool(player_nickname)
-            if not player_authenticated:
+            if not player_nickname:
                 return parameter_error_payload("player_uuid", player_uuid, message="The UUID does not match any active player")
-        else:
-            player_authenticated = False
-            player_nickname = ''
 
-        visible_game = censor_game(game, round_param, player_authenticated, player_nickname)
+        visible_game = censor_game(game, round_param, player_nickname)
 
         return response_payload(200, visible_game)
 

--- a/api/get_game.py
+++ b/api/get_game.py
@@ -1,7 +1,7 @@
 from shared.response import *
 from shared.db import get_from_dynamodb
 from shared.api_gateway import parse_event
-from shared.game import get_nickname_by_uuid, get_revealed_hands
+from shared.game import get_nickname_by_uuid, censor_game
 from shared.inputs import is_valid_uuid
 
 
@@ -26,26 +26,26 @@ def lambda_handler(event, context):
         if player_uuid and not is_valid_uuid(player_uuid):
             return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
 
-        round = body.get("round")
+        round_param = body.get("round")
 
-        if round:
-            if isinstance(round, str) and round.isdigit():
-                round = int(round)
-            elif isinstance(round, int):
+        if round_param:
+            if isinstance(round_param, str) and round_param.isdigit():
+                round_param = int(round_param)
+            elif isinstance(round_param, int):
                 pass
             else:
-                return parameter_error_payload("round", round)
+                return parameter_error_payload("round", round_param)
 
-        if round and round <= 0:
-            return parameter_error_payload("round", round, message="The round parameter is invalid - must be an integer between 1 and the current round, or -1, or blank")
+        if round_param and round_param <= 0:
+            return parameter_error_payload("round", round_param, message="The round parameter is invalid - must be an integer between 1 and the current round, or -1, or blank")
         current_round = game["round_number"]
-        if round and current_round < round:
-            return parameter_error_payload("round", round, message="The game has not reached this round")
+        if round_param and current_round < round_param:
+            return parameter_error_payload("round", round_param, message="The game has not reached this round")
 
-        if round and (round != current_round or current_status != "Running"):
-            game = get_from_dynamodb(f"{game_uuid}_{round}")
+        if round_param and (round_param != current_round or current_status != "Running"):
+            game = get_from_dynamodb(f"{game_uuid}_{round_param}")
         else:
-            round = current_round
+            round_param = current_round
 
         if player_uuid:
             player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
@@ -56,27 +56,7 @@ def lambda_handler(event, context):
             player_authenticated = False
             player_nickname = ''
 
-        revealed_hands = get_revealed_hands(game, current_round, current_status, player_authenticated, player_nickname)
-
-        private_players = []
-        for player in game["players"]:
-            private_players.append({key: player[key] for key in player if key != "uuid"})
-
-        visible_game = {
-            "admin_nickname": game["admin_nickname"],
-            "public": game["public"],
-            "room": game["room"],
-            "status": game["status"],
-            "round_number": game["round_number"],
-            "max_cards": game["max_cards"],
-            "players": private_players,
-            "hands": revealed_hands,
-            "common_hand": game.get("common_hand", []),
-            "cp_nickname": game["cp_nickname"],
-            "history": game["history"],
-            "last_modified": game["last_modified"],
-            "rules": game.get("rules", {})
-        }
+        visible_game = censor_game(game, round_param, player_authenticated, player_nickname)
 
         return response_payload(200, visible_game)
 

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -6,7 +6,6 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
-from shared.game import are_rules_unsupported_by_ai
 from shared.inputs import is_valid_uuid
 
 
@@ -93,7 +92,7 @@ def lambda_handler(event, context):
             "nickname": nickname,
             "n_cards": 0,
             "ai_agent": agent_type,
-            "ready": not are_rules_unsupported_by_ai(game.get("rules", {}))
+            "ready": True
         }
         players.append(player)
 

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -6,24 +6,23 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 
 
 AGENT_MAPPING = json.loads(os.environ.get("agent_mapping"))
 
 
-def update_in_dynamodb(game_uuid, players):
-    # # Unset readiness for all human players after AI joins - too annoying for now when people mostly play with friends or try to learn the game
-    # players = unset_human_readiness(players)
-
+def update_in_dynamodb(game_uuid, players, max_cards):
     table.update_item(
         Key={
             'game_uuid': game_uuid
         },
-        UpdateExpression="set players = :players, last_modified = :last_modified",
+        UpdateExpression="set players = :players, last_modified = :last_modified, max_cards = :mc",
         ExpressionAttributeValues={
             ':players': players,
-            ':last_modified': decimal.Decimal(str(time.time()))
+            ':last_modified': decimal.Decimal(str(time.time())),
+            ':mc': max_cards
         },
         ReturnValues="NONE"
     )
@@ -96,7 +95,9 @@ def lambda_handler(event, context):
         }
         players.append(player)
 
-        update_in_dynamodb(game_uuid, players)
+        max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
+
+        update_in_dynamodb(game_uuid, players, max_cards)
 
         payload = {"message": f"{nickname} joined the game"}
         return response_payload(200, payload)

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -6,6 +6,7 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 
@@ -56,7 +57,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Game already started")
 
         admin_uuid = body.get("admin_uuid")

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -3,7 +3,7 @@ import time
 import json
 import uuid
 import decimal
-from shared.response import * 
+from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
@@ -13,6 +13,9 @@ AGENT_MAPPING = json.loads(os.environ.get("agent_mapping"))
 
 
 def update_in_dynamodb(game_uuid, players):
+    # # Unset readiness for all human players after AI joins - too annoying for now when people mostly play with friends or try to learn the game
+    # players = unset_human_readiness(players)
+
     table.update_item(
         Key={
             'game_uuid': game_uuid
@@ -88,7 +91,8 @@ def lambda_handler(event, context):
             "uuid": player_uuid,
             "nickname": nickname,
             "n_cards": 0,
-            "ai_agent": agent_type
+            "ai_agent": agent_type,
+            "ready": True
             }
         players.append(player)
 

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -6,6 +6,7 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.game import are_rules_unsupported_by_ai
 from shared.inputs import is_valid_uuid
 
 
@@ -92,8 +93,8 @@ def lambda_handler(event, context):
             "nickname": nickname,
             "n_cards": 0,
             "ai_agent": agent_type,
-            "ready": True
-            }
+            "ready": not are_rules_unsupported_by_ai(game.get("rules", {}))
+        }
         players.append(player)
 
         update_in_dynamodb(game_uuid, players)

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -2,13 +2,16 @@ import uuid
 import time
 import re
 import decimal
-from shared.response import * 
+from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
 
 
 def update_in_dynamodb(game_uuid, players, admin_nickname):
+    # # Unset readiness for all human players after any join - too annoying for now when people mostly play with friends or try to learn the game
+    # players = unset_human_readiness(players)
+
     table.update_item(
         Key={
             'game_uuid': game_uuid
@@ -57,7 +60,7 @@ def lambda_handler(event, context):
             return parameter_error_payload("nickname", nickname, message="Nickname already taken")
 
         player_uuid = str(uuid.uuid4())
-        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0}
+        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False}
         players.append(player)
 
         admin_nickname = game.get("admin_nickname")

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
@@ -50,7 +51,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Game already started")
 
         if len(game.get("players")) == 8:

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -2,30 +2,37 @@ import uuid
 import time
 import re
 import decimal
+from botocore.exceptions import ClientError
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
+from shared.logging import logger
 
-
-def update_in_dynamodb(game_uuid, players, admin_nickname):
-    # # Unset readiness for all human players after any join - too annoying for now when people mostly play with friends or try to learn the game
-    # players = unset_human_readiness(players)
-
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set players = :players, last_modified = :last_modified, admin_nickname = :admin_nickname",
-        ExpressionAttributeValues={
-            ':players': players,
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':admin_nickname': admin_nickname
-        },
-        ReturnValues="NONE"
-    )
-    return True
-
+def update_in_dynamodb(game_uuid, players, admin_nickname, last_modified):
+    """
+    Conditionally updates the game state in DynamoDB to add a new player.
+    Returns True on success, False on failure (due to a race condition).
+    """
+    try:
+        table.update_item(
+            Key={'game_uuid': game_uuid},
+            UpdateExpression="SET players = :p, last_modified = :t, admin_nickname = :a",
+            ConditionExpression="last_modified = :lm",
+            ExpressionAttributeValues={
+                ':p': players,
+                ':t': decimal.Decimal(str(time.time())),
+                ':a': admin_nickname,
+                ':lm': last_modified
+            }
+        )
+        return True
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            logger.warning(f"Failed to join game {game_uuid} due to a race condition.")
+            return False
+        else:
+            raise
 
 def lambda_handler(event, context):
     try:
@@ -60,17 +67,14 @@ def lambda_handler(event, context):
             return parameter_error_payload("nickname", nickname, message="Nickname already taken")
 
         player_uuid = str(uuid.uuid4())
-        player = {"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False}
-        players.append(player)
+        players.append({"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False})
+        admin_nickname = game.get("admin_nickname") or nickname
 
-        admin_nickname = game.get("admin_nickname")
-        if len(players) == 1:
-            admin_nickname = nickname
-
-        update_in_dynamodb(game_uuid, players, admin_nickname)
-
-        response = {"player_uuid": player_uuid}
-        return response_payload(200, response)
+        if update_in_dynamodb(game_uuid, players, admin_nickname, game["last_modified"]):
+            return response_payload(200, {"player_uuid": player_uuid})
+        
+        logger.info(f"Join failed for '{nickname}' due to race condition.")
+        return error_payload(409, "The game state changed. Please try again.")
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -1,4 +1,3 @@
-import uuid
 import time
 import re
 import decimal
@@ -7,7 +6,7 @@ from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.constants import GameStatus
-from shared.game import calculate_actual_max_cards
+from shared.game import create_player, calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
@@ -69,13 +68,13 @@ def lambda_handler(event, context):
         if nickname in [p["nickname"] for p in players]:
             return parameter_error_payload("nickname", nickname, message="Nickname already taken")
 
-        player_uuid = str(uuid.uuid4())
-        players.append({"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False})
-        admin_nickname = game.get("admin_nickname") or nickname
+        new_player = create_player(game, nickname)
+        players.append(new_player)
+        admin_nickname = game.get("admin_nickname") or new_player.get("nickname")
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
 
         if update_in_dynamodb(game_uuid, players, admin_nickname, max_cards, game["last_modified"]):
-            return response_payload(200, {"player_uuid": player_uuid})
+            return response_payload(200, {"player_uuid": new_player.get("uuid")})
         
         logger.info(f"Join failed for '{nickname}' due to race condition.")
         return error_payload(409, "The game state changed. Please try again.")

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -6,10 +6,11 @@ from botocore.exceptions import ClientError
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 from shared.logging import logger
 
-def update_in_dynamodb(game_uuid, players, admin_nickname, last_modified):
+def update_in_dynamodb(game_uuid, players, admin_nickname, max_cards, last_modified):
     """
     Conditionally updates the game state in DynamoDB to add a new player.
     Returns True on success, False on failure (due to a race condition).
@@ -17,12 +18,13 @@ def update_in_dynamodb(game_uuid, players, admin_nickname, last_modified):
     try:
         table.update_item(
             Key={'game_uuid': game_uuid},
-            UpdateExpression="SET players = :p, last_modified = :t, admin_nickname = :a",
+            UpdateExpression="SET players = :p, last_modified = :t, admin_nickname = :a, max_cards = :mc",
             ConditionExpression="last_modified = :lm",
             ExpressionAttributeValues={
                 ':p': players,
                 ':t': decimal.Decimal(str(time.time())),
                 ':a': admin_nickname,
+                ':mc': max_cards,
                 ':lm': last_modified
             }
         )
@@ -69,8 +71,9 @@ def lambda_handler(event, context):
         player_uuid = str(uuid.uuid4())
         players.append({"uuid": player_uuid, "nickname": nickname, "n_cards": 0, "ready": False})
         admin_nickname = game.get("admin_nickname") or nickname
+        max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
 
-        if update_in_dynamodb(game_uuid, players, admin_nickname, game["last_modified"]):
+        if update_in_dynamodb(game_uuid, players, admin_nickname, max_cards, game["last_modified"]):
             return response_payload(200, {"player_uuid": player_uuid})
         
         logger.info(f"Join failed for '{nickname}' due to race condition.")

--- a/api/make_private.py
+++ b/api/make_private.py
@@ -3,6 +3,7 @@ import decimal
 from shared.response import * 
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.inputs import is_valid_uuid
 
 
@@ -38,7 +39,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Cannot make the change - game already started")
 
         admin_uuid = str(body.get("admin_uuid"))

--- a/api/make_public.py
+++ b/api/make_public.py
@@ -3,6 +3,7 @@ import decimal
 from shared.response import * 
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.inputs import is_valid_uuid
 
 
@@ -38,7 +39,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Cannot make the change - game already started")
 
         admin_uuid = str(body.get("admin_uuid"))

--- a/api/play.py
+++ b/api/play.py
@@ -7,6 +7,7 @@ from itertools import combinations
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus, RuleValues
 from shared.logging import logger
 from shared.game import get_nickname_by_uuid, censor_game, find_next_active_player, end_round, start_player_timer, get_action_ids
 from shared.inputs import is_valid_uuid
@@ -14,7 +15,7 @@ from shared.inputs import is_valid_uuid
 sqs_client = boto3.client("sqs")
 TIME_LIMIT_QUEUE_NAME = os.environ.get("time_limit_queue_name")
 
-def get_set_details_from_action_id(action_id, deck_size=24):
+def get_set_details_from_action_id(action_id, deck_size=RuleValues.DECK_SIZE_DEFAULT):
     """
     Determines the set type and details from the action_id and deck size.
     """
@@ -137,7 +138,7 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
     Checks if a given set exists within a list of cards, using a specified number of jokers.
     """
     try:
-        set_details = get_set_details_from_action_id(action_id, rules.get("deck_size", 24))
+        set_details = get_set_details_from_action_id(action_id, rules.get("deck_size", RuleValues.DECK_SIZE_DEFAULT))
         if not set_details:
             logger.error("Could not get set details from action_id.")
             return False
@@ -244,7 +245,7 @@ def lambda_handler(event, context):
         game = get_from_dynamodb(game_uuid)
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, "Game does not exist")
-        if game.get("status") != "Running":
+        if game.get("status") != GameStatus.RUNNING:
             return error_payload(400, "This game is not currently running")
 
         player_uuid = str(body.get("player_uuid"))

--- a/api/play.py
+++ b/api/play.py
@@ -103,13 +103,12 @@ def check_two_pairs(cards, value1, value2, num_jokers):
     return count1 + jokers_for_1 >= 2 and cards.count(value2) + remaining_jokers >= 2
 
 def check_straight(cards, required_values, num_jokers):
+    unique_cards = set(cards)
+    missing_cards = 0
     for value in required_values:
-        if cards.count(value) == 0:
-            if num_jokers > 0:
-                num_jokers -= 1
-            else:
-                return False
-    return True
+        if value not in unique_cards:
+            missing_cards += 1
+    return missing_cards <= num_jokers
 
 def check_three_of_a_kind(cards, value, num_jokers):
     return cards.count(value) + num_jokers >= 3
@@ -127,18 +126,18 @@ def check_four_of_a_kind(cards, value, num_jokers):
     return cards.count(value) + num_jokers >= 4
 
 def check_straight_flush(cards_with_color, color, required_values, num_jokers):
+    card_set = set(cards_with_color)
+    missing_cards = 0
     for value in required_values:
-        if (value, color) not in cards_with_color:
-            if num_jokers > 0:
-                num_jokers -= 1
-            else:
-                return False
-    return True
+        if (value, color) not in card_set:
+            missing_cards += 1
+    return missing_cards <= num_jokers
 
-def determine_set_existence(cards, action_id, rules):
+def determine_set_existence(all_cards, action_id, rules, num_jokers):
+    """
+    Checks if a given set exists within a list of cards, using a specified number of jokers.
+    """
     try:
-        logger.info(f"Checking action_id: {action_id}")
-        logger.info(f"Raw cards input: {cards}")
         set_details = get_set_details_from_action_id(action_id, rules.get("deck_size", 24))
         if not set_details:
             logger.error("Could not get set details from action_id.")
@@ -150,10 +149,9 @@ def determine_set_existence(cards, action_id, rules):
         detail_2 = set_details.get("detail_2")
         details = set_details.get("details")
 
-        num_jokers = sum(1 for card in cards if int(card["value"]) == -1)
-        card_values = [int(card["value"]) for card in cards if int(card["value"]) not in [-1, -2]]
-        card_colours = [int(card["colour"]) for card in cards if int(card["colour"]) not in [-1, -2]]
-        cards_with_color = [(int(c["value"]), int(c["colour"])) for c in cards if int(c["value"]) not in [-1, -2]]
+        card_values = [int(card["value"]) for card in all_cards if int(card["value"]) not in [-1, -2]]
+        card_colours = [int(card["colour"]) for card in all_cards if int(card["colour"]) not in [-1, -2]]
+        cards_with_color = [(int(c["value"]), int(c["colour"])) for c in all_cards if int(c["value"]) not in [-1, -2]]
         cards_by_color = {color: card_colours.count(color) for color in set(card_colours)}
 
         if set_type == "High card":
@@ -193,18 +191,31 @@ def update_in_dynamodb(game_uuid, cp_nickname, history):
 
 def handle_check(game):
     """
-    Determines the loser of a check and then calls the shared end_round function.
+    Gathers all necessary data and calls the determine_set_existence and end_round functions.
     """
     rules = game.get("rules", {})
-    all_cards = [card for hand in game["hands"] for card in hand["hand"]]
+    history = game.get("history", [])
+    
+    # Identify the player who made the bet that is being checked
+    better_nickname = history[-2]["player"]
+    action_id_being_checked = history[-2]["action_id"]
+
+    # Gather all cards from all players and the common hand
+    all_cards = [card for hand in game.get("hands", []) for card in hand.get("hand", [])]
     all_cards.extend(game.get("common_hand", []))
+    
+    # Calculate the number of usable jokers based on the new rule
+    better_hand_obj = next((hand for hand in game.get("hands", []) if hand.get("nickname") == better_nickname), None)
+    better_hand = better_hand_obj.get("hand", []) if better_hand_obj else []
+    common_hand = game.get("common_hand", [])
+    
+    num_jokers = sum(1 for card in better_hand if int(card.get("value")) == -1)
+    num_jokers += sum(1 for card in common_hand if int(card.get("value")) == -1)
 
-    set_exists = determine_set_existence(all_cards, game["history"][-2]["action_id"], rules)
+    # Call the pure evaluation function
+    set_exists = determine_set_existence(all_cards, action_id_being_checked, rules, num_jokers)
 
-    if set_exists:
-        losing_player_nickname = game["history"][-1]["player"]
-    else:
-        losing_player_nickname = game["history"][-2]["player"]
+    losing_player_nickname = history[-1]["player"] if set_exists else better_nickname
 
     return end_round(game, losing_player_nickname)
 

--- a/api/play.py
+++ b/api/play.py
@@ -175,14 +175,15 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
         print(f"Error in determine_set_existence: {err}")
         return False
 
-def update_in_dynamodb(game_uuid, cp_nickname, history):
+def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline):
     table.update_item(
         Key={'game_uuid': game_uuid},
-        UpdateExpression="set last_modified = :t, cp_nickname = :c, history = :h",
+        UpdateExpression="set last_modified = :t, cp_nickname = :c, history = :h, move_deadline = :d",
         ExpressionAttributeValues={
             ':t': decimal.Decimal(str(time.time())),
             ':c': cp_nickname,
-            ':h': history
+            ':h': history,
+            ':d': move_deadline
         }
     )
     return True
@@ -262,8 +263,8 @@ def lambda_handler(event, context):
 
         if action_id != check_action:
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
-            update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"])
-            start_player_timer(game)
+            game["move_deadline"] = start_player_timer(game)
+            update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"], game["move_deadline"])
             return response_payload(200, censor_game(game, game["round_number"], True, player_nickname))
 
         else:

--- a/api/play.py
+++ b/api/play.py
@@ -280,13 +280,13 @@ def lambda_handler(event, context):
             game["move_deadline"] = start_player_timer(game)
             if not update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"]):
                 return error_payload(409, "The game state changed.")
-            return response_payload(200, censor_game(game, game["round_number"], player_nickname))
+            return response_payload(200, censor_game(game, player_nickname))
 
         else:
             end_round_state = handle_check(game)
             if not end_round_state:
                 return error_payload(409, "The game state changed.")
-            return response_payload(200, censor_game(end_round_state, end_round_state["round_number"] + 1, player_nickname))
+            return response_payload(200, censor_game(end_round_state, player_nickname))
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/play.py
+++ b/api/play.py
@@ -201,8 +201,7 @@ def handle_check(game):
 
     set_exists = determine_set_existence(all_cards, game["history"][-2]["action_id"], rules)
 
-    standard_order = rules.get("standard_order", True)
-    if (set_exists and standard_order) or (not set_exists and not standard_order):
+    if set_exists:
         losing_player_nickname = game["history"][-1]["player"]
     else:
         losing_player_nickname = game["history"][-2]["player"]
@@ -239,7 +238,6 @@ def lambda_handler(event, context):
         rules = game.get("rules", {})
         action_ids = get_action_ids(rules)
         check_action = action_ids["check"]
-        standard_order = rules.get("standard_order", True)
 
         if not (0 <= action_id <= check_action):
             return parameter_error_payload("action_id", action_id, f"Action ID must be between 0 and {check_action}")
@@ -249,12 +247,8 @@ def lambda_handler(event, context):
         if action_id == check_action:
             if last_action_id == -1:
                 return error_payload(400, "Cannot check as the first action of a round.")
-        elif standard_order:
-            if action_id <= last_action_id:
-                return error_payload(400, "Action must be of a higher rank")
-        else:
-            if action_id >= last_action_id and last_action_id != -1:
-                 return error_payload(400, "Action must be of a lower rank")
+        elif action_id <= last_action_id:
+            return error_payload(400, "Action must be of a higher rank")
 
         game["history"].append({"player": player_nickname, "action_id": action_id})
 

--- a/api/play.py
+++ b/api/play.py
@@ -1,243 +1,213 @@
 import time
-import copy
 import decimal
-from random import sample
-from shared.response import * 
-from shared.db import table, get_from_dynamodb, save_in_dynamodb
+import os
+import boto3
+from itertools import combinations
+from shared.response import *
+from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
-from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, draw_cards
+from shared.logging import logger
+from shared.game import get_nickname_by_uuid, censor_game, find_next_active_player, end_round, start_player_timer, get_action_ids
 from shared.inputs import is_valid_uuid
 
+sqs_client = boto3.client("sqs")
+TIME_LIMIT_QUEUE_NAME = os.environ.get("time_limit_queue_name")
 
-INDEXATION_CSV = """action_id,set_type,detail_1,detail_2
-0,High card,0,
-1,High card,1,
-2,High card,2,
-3,High card,3,
-4,High card,4,
-5,High card,5,
-6,Pair,0,
-7,Pair,1,
-8,Pair,2,
-9,Pair,3,
-10,Pair,4,
-11,Pair,5,
-12,Two pairs,1,0
-13,Two pairs,2,0
-14,Two pairs,2,1
-15,Two pairs,3,0
-16,Two pairs,3,1
-17,Two pairs,3,2
-18,Two pairs,4,0
-19,Two pairs,4,1
-20,Two pairs,4,2
-21,Two pairs,4,3
-22,Two pairs,5,0
-23,Two pairs,5,1
-24,Two pairs,5,2
-25,Two pairs,5,3
-26,Two pairs,5,4
-27,Small straight,,
-28,Big straight,,
-29,Great straight,,
-30,Three of a kind,0,
-31,Three of a kind,1,
-32,Three of a kind,2,
-33,Three of a kind,3,
-34,Three of a kind,4,
-35,Three of a kind,5,
-36,Full house,0,1
-37,Full house,0,2
-38,Full house,0,3
-39,Full house,0,4
-40,Full house,0,5
-41,Full house,1,0
-42,Full house,1,2
-43,Full house,1,3
-44,Full house,1,4
-45,Full house,1,5
-46,Full house,2,0
-47,Full house,2,1
-48,Full house,2,3
-49,Full house,2,4
-50,Full house,2,5
-51,Full house,3,0
-52,Full house,3,1
-53,Full house,3,2
-54,Full house,3,4
-55,Full house,3,5
-56,Full house,4,0
-57,Full house,4,1
-58,Full house,4,2
-59,Full house,4,3
-60,Full house,4,5
-61,Full house,5,0
-62,Full house,5,1
-63,Full house,5,2
-64,Full house,5,3
-65,Full house,5,4
-66,Colour,0,
-67,Colour,1,
-68,Colour,2,
-69,Colour,3,
-70,Four of a kind,0,
-71,Four of a kind,1,
-72,Four of a kind,2,
-73,Four of a kind,3,
-74,Four of a kind,4,
-75,Four of a kind,5,
-76,Small flush,0,
-77,Small flush,1,
-78,Small flush,2,
-79,Small flush,3,
-80,Big flush,0,
-81,Big flush,1,
-82,Big flush,2,
-83,Big flush,3,
-84,Great flush,0,
-85,Great flush,1,
-86,Great flush,2,
-87,Great flush,3,"""
+def get_set_details_from_action_id(action_id, deck_size=24):
+    """
+    Determines the set type and details from the action_id and deck size.
+    """
+    action_id = int(action_id)
+    # Define base parameters based on deck size
+    if deck_size == 24:
+        vals = 6
+        straight_types = {
+            "Small straight": list(range(5)),
+            "Big straight": list(range(1, 6)),
+            "Great straight": list(range(6)),
+        }
+        flush_straight_types = straight_types
+    else:  # deck_size == 32
+        vals = 8
+        straight_types = {f"Straight {i+1}": list(range(i, i + 5)) for i in range(4)}
+        flush_straight_types = {f"Straight flush {i+1}": list(range(i, i + 5)) for i in range(4)}
 
+    # Dynamically calculate the boundaries for each set type
+    current_boundary = 0
+    boundaries = {}
+    boundaries["High card"] = current_boundary + vals
+    current_boundary = boundaries["High card"]
+    boundaries["Pair"] = current_boundary + vals
+    current_boundary = boundaries["Pair"]
+    boundaries["Two pairs"] = current_boundary + (vals * (vals - 1)) // 2
+    current_boundary = boundaries["Two pairs"]
+    boundaries["Straight"] = current_boundary + len(straight_types)
+    current_boundary = boundaries["Straight"]
+    boundaries["Three of a kind"] = current_boundary + vals
+    current_boundary = boundaries["Three of a kind"]
+    boundaries["Full house"] = current_boundary + (vals * (vals - 1))
+    current_boundary = boundaries["Full house"]
+    boundaries["Colour"] = current_boundary + 4
+    current_boundary = boundaries["Colour"]
+    boundaries["Four of a kind"] = current_boundary + vals
+    current_boundary = boundaries["Four of a kind"]
+    boundaries["Straight flush"] = current_boundary + (len(flush_straight_types) * 4)
+    current_boundary = boundaries["Straight flush"]
 
-def load_indexation():
-    header = None
-    indexation = []
-    for line in INDEXATION_CSV.split("\n"):
-        if not header:
-            header = line
-            continue
-        action_id, set_type, detail_1, detail_2 = line.split(",")
-        indexation.append({"action_id": action_id,
-                           "set_type": set_type,
-                           "detail_1": detail_1,
-                           "detail_2": detail_2
-                           })
-    return indexation
+    if action_id < boundaries["High card"]:
+        return {"set_type": "High card", "detail_1": action_id}
+    if action_id < boundaries["Pair"]:
+        return {"set_type": "Pair", "detail_1": action_id - boundaries["High card"]}
+    if action_id < boundaries["Two pairs"]:
+        offset = action_id - boundaries["Pair"]
+        pairs = list(combinations(reversed(range(vals)), 2))
+        pair_index = len(pairs) - 1 - offset
+        d1, d2 = pairs[pair_index]
+        return {"set_type": "Two pairs", "detail_1": d1, "detail_2": d2}
+    if action_id < boundaries["Straight"]:
+        offset = action_id - boundaries["Two pairs"]
+        set_name, details = list(straight_types.items())[offset]
+        return {"set_type": set_name, "details": details}
+    if action_id < boundaries["Three of a kind"]:
+        return {"set_type": "Three of a kind", "detail_1": action_id - boundaries["Straight"]}
+    if action_id < boundaries["Full house"]:
+        offset = action_id - boundaries["Three of a kind"]
+        d1 = offset // (vals - 1)
+        d2 = offset % (vals - 1)
+        if d2 >= d1: d2 += 1
+        return {"set_type": "Full house", "detail_1": d1, "detail_2": d2}
+    if action_id < boundaries["Colour"]:
+        return {"set_type": "Colour", "detail_1": action_id - boundaries["Full house"]}
+    if action_id < boundaries["Four of a kind"]:
+        return {"set_type": "Four of a kind", "detail_1": action_id - boundaries["Colour"]}
+    if action_id < boundaries["Straight flush"]:
+        offset = action_id - boundaries["Four of a kind"]
+        suit = offset % 4
+        straight_type_index = offset // 4
+        set_name, details = list(flush_straight_types.items())[straight_type_index]
+        # Rename to a generic "Straight flush" for the check logic
+        return {"set_type": "Straight flush", "detail_1": suit, "details": details}
 
+    return None # Should not be reached with a valid action_id
 
-def find_next_active_player(players, cp_nickname):
-    active_players = [player for player in players if player["n_cards"] != 0 or player["nickname"] == cp_nickname]
-    current_player_order = [i for i, player in enumerate(active_players) if player["nickname"] == cp_nickname][0]
-    next_active_player = (active_players * 2)[current_player_order + 1]
-    return next_active_player
+def check_high_card(cards, value, num_jokers):
+    return cards.count(value) + num_jokers >= 1
 
+def check_pair(cards, value, num_jokers):
+    return cards.count(value) + num_jokers >= 2
 
-def determine_set_existence(cards, action_id):
+def check_two_pairs(cards, value1, value2, num_jokers):
+    count1 = cards.count(value1)
+    jokers_for_1 = min(num_jokers, 2 - count1)
+    remaining_jokers = num_jokers - jokers_for_1
+    return count1 + jokers_for_1 >= 2 and cards.count(value2) + remaining_jokers >= 2
+
+def check_straight(cards, required_values, num_jokers):
+    for value in required_values:
+        if cards.count(value) == 0:
+            if num_jokers > 0:
+                num_jokers -= 1
+            else:
+                return False
+    return True
+
+def check_three_of_a_kind(cards, value, num_jokers):
+    return cards.count(value) + num_jokers >= 3
+
+def check_full_house(cards, value1, value2, num_jokers):
+    count1 = cards.count(value1)
+    jokers_for_3 = min(num_jokers, 3 - count1)
+    remaining_jokers = num_jokers - jokers_for_3
+    return count1 + jokers_for_3 >= 3 and cards.count(value2) + remaining_jokers >= 2
+
+def check_flush(cards_by_color, color, num_jokers):
+    return cards_by_color.get(color, 0) + num_jokers >= 5
+
+def check_four_of_a_kind(cards, value, num_jokers):
+    return cards.count(value) + num_jokers >= 4
+
+def check_straight_flush(cards_with_color, color, required_values, num_jokers):
+    for value in required_values:
+        if (value, color) not in cards_with_color:
+            if num_jokers > 0:
+                num_jokers -= 1
+            else:
+                return False
+    return True
+
+def determine_set_existence(cards, action_id, rules):
     try:
-        action_id = int(action_id)
-        indexation = load_indexation()
-        set_row = indexation[action_id]
-        set_type = set_row["set_type"]
-        detail_1 = int(set_row["detail_1"]) if set_row["detail_1"] else None
-        detail_2 = int(set_row["detail_2"]) if set_row["detail_2"] else None
-        card_values = [card["value"] for card in cards]
-        card_colours = [card["colour"] for card in cards]
+        logger.info(f"Checking action_id: {action_id}")
+        logger.info(f"Raw cards input: {cards}")
+        set_details = get_set_details_from_action_id(action_id, rules.get("deck_size", 24))
+        if not set_details:
+            logger.error("Could not get set details from action_id.")
+            return False
+        logger.info(f"Set details from action_id: {set_details}")
+
+        set_type = set_details["set_type"]
+        detail_1 = set_details.get("detail_1")
+        detail_2 = set_details.get("detail_2")
+        details = set_details.get("details")
+
+        num_jokers = sum(1 for card in cards if int(card["value"]) == -1)
+        card_values = [int(card["value"]) for card in cards if int(card["value"]) not in [-1, -2]]
+        card_colours = [int(card["colour"]) for card in cards if int(card["colour"]) not in [-1, -2]]
+        cards_with_color = [(int(c["value"]), int(c["colour"])) for c in cards if int(c["value"]) not in [-1, -2]]
+        cards_by_color = {color: card_colours.count(color) for color in set(card_colours)}
 
         if set_type == "High card":
-            return card_values.count(detail_1) >= 1
+            return check_high_card(card_values, detail_1, num_jokers)
         elif set_type == "Pair":
-            return card_values.count(detail_1) >= 2
+            return check_pair(card_values, detail_1, num_jokers)
         elif set_type == "Two pairs":
-            return card_values.count(detail_1) >= 2 and card_values.count(detail_2) >= 2
-        elif set_type == "Small straight":
-            return card_values.count(0) > 0 and card_values.count(1) > 0 and card_values.count(2) > 0 and card_values.count(3) > 0 and card_values.count(4) > 0
-        elif set_type == "Big straight":
-            return card_values.count(1) > 0 and card_values.count(2) > 0 and card_values.count(3) > 0 and card_values.count(4) > 0 and card_values.count(5) > 0
-        elif set_type == "Great straight":
-            return card_values.count(0) > 0 and card_values.count(1) > 0 and card_values.count(2) > 0 and card_values.count(3) > 0 and card_values.count(4) > 0 and card_values.count(5) > 0
+            return check_two_pairs(card_values, detail_1, detail_2, num_jokers)
+        elif "straight" in set_type.lower() and "flush" not in set_type.lower():
+            return check_straight(card_values, details, num_jokers)
         elif set_type == "Three of a kind":
-            return card_values.count(detail_1) >= 3
+            return check_three_of_a_kind(card_values, detail_1, num_jokers)
         elif set_type == "Full house":
-            return card_values.count(detail_1) >= 3 and card_values.count(detail_2) >= 2
+            return check_full_house(card_values, detail_1, detail_2, num_jokers)
         elif set_type == "Colour":
-            return card_colours.count(detail_1) >= 5
+            return check_flush(cards_by_color, detail_1, num_jokers)
         elif set_type == "Four of a kind":
-            return card_values.count(detail_1) >= 4
-        elif set_type == "Small flush":
-            relevant_values = [card["value"] for card in cards if card["colour"] == detail_1]
-            if not relevant_values:
-                return False
-            return relevant_values.count(0) > 0 and relevant_values.count(1) > 0 and relevant_values.count(2) > 0 and relevant_values.count(3) > 0 and relevant_values.count(4) > 0
-        elif set_type == "Big flush":
-            relevant_values = [card["value"] for card in cards if card["colour"] == detail_1]
-            if not relevant_values:
-                return False
-            return relevant_values.count(1) > 0 and relevant_values.count(2) > 0 and relevant_values.count(3) > 0 and relevant_values.count(4) > 0 and relevant_values.count(5) > 0
-        elif set_type == "Great flush":
-            relevant_values = [card["value"] for card in cards if card["colour"] == detail_1]
-            if not relevant_values:
-                return False
-            return relevant_values.count(0) > 0 and relevant_values.count(1) > 0 and relevant_values.count(2) > 0 and relevant_values.count(3) > 0 and relevant_values.count(4) > 0 and relevant_values.count(5) > 0
-
+            return check_four_of_a_kind(card_values, detail_1, num_jokers)
+        elif "straight flush" in set_type.lower():
+            return check_straight_flush(cards_with_color, detail_1, details, num_jokers)
         return False
-
     except Exception as err:
-        raise type(err)(f"{err} \n Failed in determine_set_existence")
-
+        print(f"Error in determine_set_existence: {err}")
+        return False
 
 def update_in_dynamodb(game_uuid, cp_nickname, history):
     table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set last_modified = :last_modified, cp_nickname = :cp_nickname, history = :history",
+        Key={'game_uuid': game_uuid},
+        UpdateExpression="set last_modified = :t, cp_nickname = :c, history = :h",
         ExpressionAttributeValues={
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':cp_nickname': cp_nickname,
-            ':history': history
-        },
-        ReturnValues="NONE"
+            ':t': decimal.Decimal(str(time.time())),
+            ':c': cp_nickname,
+            ':h': history
+        }
     )
     return True
 
-
 def handle_check(game):
-    cp_nickname = game["cp_nickname"]
-    cards = [card for hand in game["hands"] for card in hand["hand"]]
-    set_exists = determine_set_existence(cards, game["history"][-2]["action_id"])
-    if set_exists:
-        losing_player = get_player_by_nickname(game["players"], game["history"][-1]["player"])
+    """
+    Determines the loser of a check and then calls the shared end_round function.
+    """
+    rules = game.get("rules", {})
+    all_cards = [card for hand in game["hands"] for card in hand["hand"]]
+    all_cards.extend(game.get("common_hand", []))
+
+    set_exists = determine_set_existence(all_cards, game["history"][-2]["action_id"], rules)
+
+    standard_order = rules.get("standard_order", True)
+    if (set_exists and standard_order) or (not set_exists and not standard_order):
+        losing_player_nickname = game["history"][-1]["player"]
     else:
-        losing_player = get_player_by_nickname(game["players"], game["history"][-2]["player"])
+        losing_player_nickname = game["history"][-2]["player"]
 
-    game["history"].append({"player": losing_player["nickname"], "action_id": 89})
-    game["cp_nickname"] = None
-    end_round_game_state = copy.deepcopy(game)
-
-    game_uuid = game["game_uuid"]
-    # Store the last round separately
-    game["game_uuid"] += "_" + str(int(game['round_number']))
-    if not save_in_dynamodb(game):
-        raise Exception("Can't save game data")
-    game["game_uuid"] = game_uuid
-
-    losing_player["n_cards"] += 1
-    # If a player surpasses max cards, make them inactive (set their n_cards to 0) and either finish the game or set up next round
-    if losing_player["n_cards"] > game["max_cards"]:
-        losing_player["n_cards"] = 0
-        # Check if game is finished
-        if sum(p["n_cards"] > 0 for p in game["players"]) == 1:
-            game["status"] = "Finished"
-        else:
-            # If the checking player was eliminated, figure out the next player
-            # Otherwise the current player doesn't change
-            if losing_player["nickname"] == cp_nickname:
-                game["cp_nickname"] = find_next_active_player(game["players"], cp_nickname)["nickname"]
-            else:
-                game["cp_nickname"] = cp_nickname
-    else:
-        # If no one is kicked out, picking the next player is easier
-        game["cp_nickname"] = losing_player["nickname"]
-
-    game["round_number"] += 1
-    game["history"] = []
-    game["hands"] = draw_cards(game["players"])
-
-    # Overwrite the game object - for simplicity (instead of elaborate update)
-    if save_in_dynamodb(game):
-        return end_round_game_state
-
+    return end_round(game, losing_player_nickname)
 
 def lambda_handler(event, context):
     try:
@@ -247,64 +217,57 @@ def lambda_handler(event, context):
 
         game_uuid = str(body.get("game_uuid"))
         if not is_valid_uuid(game_uuid):
-            return parameter_error_payload("game_uuid", game_uuid, message="Invalid game UUID")
+            return parameter_error_payload("game_uuid", game_uuid, "Invalid game UUID")
 
         game = get_from_dynamodb(game_uuid)
         if not game:
-            return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
-
-        current_status = game.get("status")
-
-        if current_status == "Not started":
-            return error_payload(400, "This game has not yet started")
-        if current_status == "Finished":
-            return error_payload(400, "This game has already finished")
+            return parameter_error_payload("game_uuid", game_uuid, "Game does not exist")
+        if game.get("status") != "Running":
+            return error_payload(400, "This game is not currently running")
 
         player_uuid = str(body.get("player_uuid"))
-        if not player_uuid:
-            return parameter_error_payload("player_uuid", player_uuid, message="Player UUID missing - please supply it")
-        if not is_valid_uuid(player_uuid):
-            return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
-
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-        player_authenticated = bool(player_nickname)
-        is_current_player = player_nickname == game["cp_nickname"]
-        if player_uuid and not player_authenticated:
-            return parameter_error_payload("player_uuid", player_uuid, message="The UUID does not match any active player")
-        if not is_current_player:
-            return parameter_error_payload("player_uuid", player_uuid, message="The submitted UUID does not match the UUID of the current player")
+        if not player_nickname or player_nickname != game["cp_nickname"]:
+            return parameter_error_payload("player_uuid", player_uuid, "Not your turn or invalid player UUID")
 
         action_id = body.get("action_id")
-
-        if not action_id:
-            parameter_error_payload("action_id", action_id, message="Action ID missing - please supply it")
-        if isinstance(action_id, str) and action_id.isdigit():
+        try:
             action_id = int(action_id)
-        elif isinstance(action_id, int):
-            pass
-        else:
-            return parameter_error_payload("action_id", action_id)
+        except (ValueError, TypeError):
+            return parameter_error_payload("action_id", action_id, "Action ID must be an integer")
 
-        if action_id < 0 or action_id > 88:
-            return parameter_error_payload("action_id", action_id, message="Action ID must be an integer between 0 and 88")
-        elif not game["history"] and action_id == 88 or game["history"] and action_id <= game["history"][-1]["action_id"]:
-            return error_payload(400, "This action not allowed right now")
+        rules = game.get("rules", {})
+        action_ids = get_action_ids(rules)
+        check_action = action_ids["check"]
+        standard_order = rules.get("standard_order", True)
+
+        if not (0 <= action_id <= check_action):
+            return parameter_error_payload("action_id", action_id, f"Action ID must be between 0 and {check_action}")
+
+        last_action_id = game["history"][-1]["action_id"] if game.get("history") else -1
+
+        if action_id == check_action:
+            if last_action_id == -1:
+                return error_payload(400, "Cannot check as the first action of a round.")
+        elif standard_order:
+            if action_id <= last_action_id:
+                return error_payload(400, "Action must be of a higher rank")
+        else:
+            if action_id >= last_action_id and last_action_id != -1:
+                 return error_payload(400, "Action must be of a lower rank")
 
         game["history"].append({"player": player_nickname, "action_id": action_id})
 
-        if action_id != 88:
+        if action_id != check_action:
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
-            if update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"]):
-                visible_game = censor_game(game, game["round_number"], player_authenticated, player_nickname)
-                return response_payload(200, visible_game)
-            raise Exception("Something went wrong - could not update game data")
+            update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"])
+            start_player_timer(game)
+            return response_payload(200, censor_game(game, game["round_number"], True, player_nickname))
 
-        if action_id == 88:
+        else:
             end_round_game_state = handle_check(game)
-            visible_game = censor_game(end_round_game_state, game["round_number"], player_authenticated, player_nickname)
+            visible_game = censor_game(end_round_game_state, end_round_game_state["round_number"] + 1, True, player_nickname)
             return response_payload(200, visible_game)
-
-        raise(Exception("Something went wrong - ended up with no response"))
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/play.py
+++ b/api/play.py
@@ -47,8 +47,8 @@ def get_set_details_from_action_id(action_id, deck_size=24):
     current_boundary = boundaries["Three of a kind"]
     boundaries["Full house"] = current_boundary + (vals * (vals - 1))
     current_boundary = boundaries["Full house"]
-    boundaries["Colour"] = current_boundary + 4
-    current_boundary = boundaries["Colour"]
+    boundaries["Flush"] = current_boundary + 4
+    current_boundary = boundaries["Flush"]
     boundaries["Four of a kind"] = current_boundary + vals
     current_boundary = boundaries["Four of a kind"]
     boundaries["Straight flush"] = current_boundary + (len(flush_straight_types) * 4)
@@ -76,10 +76,10 @@ def get_set_details_from_action_id(action_id, deck_size=24):
         d2 = offset % (vals - 1)
         if d2 >= d1: d2 += 1
         return {"set_type": "Full house", "detail_1": d1, "detail_2": d2}
-    if action_id < boundaries["Colour"]:
-        return {"set_type": "Colour", "detail_1": action_id - boundaries["Full house"]}
+    if action_id < boundaries["Flush"]:
+        return {"set_type": "Flush", "detail_1": action_id - boundaries["Full house"]}
     if action_id < boundaries["Four of a kind"]:
-        return {"set_type": "Four of a kind", "detail_1": action_id - boundaries["Colour"]}
+        return {"set_type": "Four of a kind", "detail_1": action_id - boundaries["Flush"]}
     if action_id < boundaries["Straight flush"]:
         offset = action_id - boundaries["Four of a kind"]
         suit = offset % 4
@@ -97,10 +97,9 @@ def check_pair(cards, value, num_jokers):
     return cards.count(value) + num_jokers >= 2
 
 def check_two_pairs(cards, value1, value2, num_jokers):
-    count1 = cards.count(value1)
-    jokers_for_1 = min(num_jokers, 2 - count1)
-    remaining_jokers = num_jokers - jokers_for_1
-    return count1 + jokers_for_1 >= 2 and cards.count(value2) + remaining_jokers >= 2
+    jokers_needed_for_value1 = max(0, 2 - cards.count(value1))
+    jokers_needed_for_value2 = max(0, 2 - cards.count(value2))
+    return (jokers_needed_for_value1 + jokers_needed_for_value2) <= num_jokers
 
 def check_straight(cards, required_values, num_jokers):
     unique_cards = set(cards)
@@ -114,22 +113,21 @@ def check_three_of_a_kind(cards, value, num_jokers):
     return cards.count(value) + num_jokers >= 3
 
 def check_full_house(cards, value1, value2, num_jokers):
-    count1 = cards.count(value1)
-    jokers_for_3 = min(num_jokers, 3 - count1)
-    remaining_jokers = num_jokers - jokers_for_3
-    return count1 + jokers_for_3 >= 3 and cards.count(value2) + remaining_jokers >= 2
+    jokers_needed_for_value1 = max(0, 3 - cards.count(value1))
+    jokers_needed_for_value2 = max(0, 2 - cards.count(value2))
+    return (jokers_needed_for_value1 + jokers_needed_for_value2) <= num_jokers
 
-def check_flush(cards_by_color, color, num_jokers):
-    return cards_by_color.get(color, 0) + num_jokers >= 5
+def check_flush(cards_by_colour, colour, num_jokers):
+    return cards_by_colour.get(colour, 0) + num_jokers >= 5
 
 def check_four_of_a_kind(cards, value, num_jokers):
     return cards.count(value) + num_jokers >= 4
 
-def check_straight_flush(cards_with_color, color, required_values, num_jokers):
-    card_set = set(cards_with_color)
+def check_straight_flush(cards_with_colour, colour, required_values, num_jokers):
+    card_set = set(cards_with_colour)
     missing_cards = 0
     for value in required_values:
-        if (value, color) not in card_set:
+        if (value, colour) not in card_set:
             missing_cards += 1
     return missing_cards <= num_jokers
 
@@ -151,8 +149,8 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
 
         card_values = [int(card["value"]) for card in all_cards if int(card["value"]) not in [-1, -2]]
         card_colours = [int(card["colour"]) for card in all_cards if int(card["colour"]) not in [-1, -2]]
-        cards_with_color = [(int(c["value"]), int(c["colour"])) for c in all_cards if int(c["value"]) not in [-1, -2]]
-        cards_by_color = {color: card_colours.count(color) for color in set(card_colours)}
+        cards_with_colour = [(int(c["value"]), int(c["colour"])) for c in all_cards if int(c["value"]) not in [-1, -2]]
+        cards_by_colour = {colour: card_colours.count(colour) for colour in set(card_colours)}
 
         if set_type == "High card":
             return check_high_card(card_values, detail_1, num_jokers)
@@ -166,12 +164,12 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
             return check_three_of_a_kind(card_values, detail_1, num_jokers)
         elif set_type == "Full house":
             return check_full_house(card_values, detail_1, detail_2, num_jokers)
-        elif set_type == "Colour":
-            return check_flush(cards_by_color, detail_1, num_jokers)
+        elif set_type == "Flush":
+            return check_flush(cards_by_colour, detail_1, num_jokers)
         elif set_type == "Four of a kind":
             return check_four_of_a_kind(card_values, detail_1, num_jokers)
         elif "straight flush" in set_type.lower():
-            return check_straight_flush(cards_with_color, detail_1, details, num_jokers)
+            return check_straight_flush(cards_with_colour, detail_1, details, num_jokers)
         return False
     except Exception as err:
         print(f"Error in determine_set_existence: {err}")
@@ -196,7 +194,7 @@ def handle_check(game):
     rules = game.get("rules", {})
     history = game.get("history", [])
     
-    # Identify the player who made the bet that is being checked
+    # Identify the checked bet and player
     better_nickname = history[-2]["player"]
     action_id_being_checked = history[-2]["action_id"]
 
@@ -204,15 +202,14 @@ def handle_check(game):
     all_cards = [card for hand in game.get("hands", []) for card in hand.get("hand", [])]
     all_cards.extend(game.get("common_hand", []))
     
-    # Calculate the number of usable jokers based on the new rule
+    # Calculate the number of usable jokers
     better_hand_obj = next((hand for hand in game.get("hands", []) if hand.get("nickname") == better_nickname), None)
     better_hand = better_hand_obj.get("hand", []) if better_hand_obj else []
     common_hand = game.get("common_hand", [])
-    
     num_jokers = sum(1 for card in better_hand if int(card.get("value")) == -1)
     num_jokers += sum(1 for card in common_hand if int(card.get("value")) == -1)
 
-    # Call the pure evaluation function
+    # Call the evaluation function
     set_exists = determine_set_existence(all_cards, action_id_being_checked, rules, num_jokers)
 
     losing_player_nickname = history[-1]["player"] if set_exists else better_nickname

--- a/api/play.py
+++ b/api/play.py
@@ -2,6 +2,7 @@ import time
 import decimal
 import os
 import boto3
+from botocore.exceptions import ClientError
 from itertools import combinations
 from shared.response import *
 from shared.db import table, get_from_dynamodb
@@ -175,18 +176,31 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
         print(f"Error in determine_set_existence: {err}")
         return False
 
-def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline):
-    table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression="set last_modified = :t, cp_nickname = :c, history = :h, move_deadline = :d",
-        ExpressionAttributeValues={
-            ':t': decimal.Decimal(str(time.time())),
-            ':c': cp_nickname,
-            ':h': history,
-            ':d': move_deadline
-        }
-    )
-    return True
+def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modified):
+    """
+    Conditionally updates the game state in DynamoDB.
+    Returns True on success, False on failure (due to race condition).
+    """
+    try:
+        table.update_item(
+            Key={'game_uuid': game_uuid},
+            UpdateExpression="SET last_modified = :t, cp_nickname = :c, history = :h, move_deadline = :d",
+            ConditionExpression="last_modified = :lm",
+            ExpressionAttributeValues={
+                ':t': decimal.Decimal(str(time.time())),
+                ':c': cp_nickname,
+                ':h': history,
+                ':d': move_deadline,
+                ':lm': last_modified
+            }
+        )
+        return True
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            logger.warning("Failed to update game state due to a race condition (play vs timeout).")
+            return False
+        else:
+            raise
 
 def handle_check(game):
     """
@@ -264,13 +278,15 @@ def lambda_handler(event, context):
         if action_id != check_action:
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
             game["move_deadline"] = start_player_timer(game)
-            update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"], game["move_deadline"])
+            if not update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"]):
+                return error_payload(409, "The game state changed.")
             return response_payload(200, censor_game(game, game["round_number"], player_nickname))
 
         else:
-            end_round_game_state = handle_check(game)
-            visible_game = censor_game(end_round_game_state, end_round_game_state["round_number"] + 1, player_nickname)
-            return response_payload(200, visible_game)
+            end_round_state = handle_check(game)
+            if not end_round_state:
+                return error_payload(409, "The game state changed.")
+            return response_payload(200, censor_game(end_round_state, end_round_state["round_number"] + 1, player_nickname))
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/play.py
+++ b/api/play.py
@@ -265,11 +265,11 @@ def lambda_handler(event, context):
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
             game["move_deadline"] = start_player_timer(game)
             update_in_dynamodb(game_uuid, game["cp_nickname"], game["history"], game["move_deadline"])
-            return response_payload(200, censor_game(game, game["round_number"], True, player_nickname))
+            return response_payload(200, censor_game(game, game["round_number"], player_nickname))
 
         else:
             end_round_game_state = handle_check(game)
-            visible_game = censor_game(end_round_game_state, end_round_game_state["round_number"] + 1, True, player_nickname)
+            visible_game = censor_game(end_round_game_state, end_round_game_state["round_number"] + 1, player_nickname)
             return response_payload(200, visible_game)
 
     except Exception as err:

--- a/api/remove_ais.py
+++ b/api/remove_ais.py
@@ -1,0 +1,58 @@
+import time
+import decimal
+from shared.response import *
+from shared.db import table, get_from_dynamodb
+from shared.api_gateway import parse_event
+from shared.inputs import is_valid_uuid
+
+def update_in_dynamodb(game_uuid, players):
+    table.update_item(
+        Key={
+            'game_uuid': game_uuid
+        },
+        UpdateExpression="set players = :players, last_modified = :last_modified",
+        ExpressionAttributeValues={
+            ':players': players,
+            ':last_modified': decimal.Decimal(str(time.time()))
+        },
+        ReturnValues="NONE"
+    )
+    return True
+
+def lambda_handler(event, context):
+    try:
+        body = parse_event(event)
+        if not body:
+            return request_error_payload(event)
+
+        game_uuid = str(body.get("game_uuid"))
+        if not is_valid_uuid(game_uuid):
+            return parameter_error_payload("game_uuid", game_uuid, message="Invalid game UUID")
+
+        game = get_from_dynamodb(game_uuid)
+        if not game:
+            return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
+
+        if game.get("status") != "Not started":
+            return error_payload(403, "Cannot remove AIs after the game has started")
+
+        admin_uuid = str(body.get("admin_uuid"))
+        if not is_valid_uuid(admin_uuid):
+            return parameter_error_payload("admin_uuid", admin_uuid, message="Invalid admin UUID")
+
+        players = game.get("players")            
+        game_admin_uuid = [player["uuid"] for player in players if player["nickname"] == game.get("admin_nickname")][0]
+        if game_admin_uuid != admin_uuid:
+            return parameter_error_payload("admin_uuid", admin_uuid, message="Admin UUID does not match")
+
+        human_players = [p for p in players if not p.get("ai_agent")]
+
+        if len(human_players) == len(players):
+            return response_payload(200, {"message": "No AI players to remove."})
+
+        update_in_dynamodb(game_uuid, human_players)
+
+        return response_payload(200, {"message": "All AI players have been removed."})
+
+    except Exception as err:
+        return internal_error_payload(err)

--- a/api/remove_ais.py
+++ b/api/remove_ais.py
@@ -3,16 +3,18 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 
-def update_in_dynamodb(game_uuid, players):
+def update_in_dynamodb(game_uuid, players, max_cards):
     table.update_item(
         Key={
             'game_uuid': game_uuid
         },
-        UpdateExpression="set players = :players, last_modified = :last_modified",
+        UpdateExpression="set players = :players, max_cards = :mc, last_modified = :last_modified",
         ExpressionAttributeValues={
             ':players': players,
+            ':mc': max_cards,
             ':last_modified': decimal.Decimal(str(time.time()))
         },
         ReturnValues="NONE"
@@ -49,8 +51,10 @@ def lambda_handler(event, context):
 
         if len(human_players) == len(players):
             return response_payload(200, {"message": "No AI players to remove."})
+        
+        max_cards = calculate_actual_max_cards(game.get("rules", {}), len(human_players))
 
-        update_in_dynamodb(game_uuid, human_players)
+        update_in_dynamodb(game_uuid, human_players, max_cards)
 
         return response_payload(200, {"message": "All AI players have been removed."})
 

--- a/api/remove_ais.py
+++ b/api/remove_ais.py
@@ -3,6 +3,7 @@ import decimal
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards
 from shared.inputs import is_valid_uuid
 
@@ -35,7 +36,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Cannot remove AIs after the game has started")
 
         admin_uuid = str(body.get("admin_uuid"))

--- a/api/send-reaction.py
+++ b/api/send-reaction.py
@@ -70,8 +70,7 @@ def lambda_handler(event, context):
             return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
         elif player_uuid:
             player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-            player_authenticated = bool(player_nickname)
-            if not player_authenticated:
+            if not player_nickname:
                 return parameter_error_payload("player_uuid", player_uuid, message="The UUID does not match any active player")
             if player_nickname == declared_nickname:
                 nickname_authenticated = "true"

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -55,6 +55,9 @@ def lambda_handler(event, context):
         if player_index == -1:
             return parameter_error_payload("player_uuid", player_uuid, message="Player not found in this game")
 
+        if len(game.get("players", [])) < 2:
+            return error_payload(403, "Cannot set readiness with only one player in the room.")
+
         updated_game_state = update_player_readiness(game_uuid, player_index, ready)
 
         game_status = updated_game_state.get("status")

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -4,6 +4,7 @@ import copy
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.game import update_n_cards
 from shared.inputs import is_valid_uuid
 from shared.game import start_game, start_next_round, get_player_by_nickname, get_action_ids
 
@@ -62,14 +63,9 @@ def lambda_handler(event, context):
 
         game_status = updated_game_state.get("status")
         if game_status == "Waiting for ready":
-            temp_players = copy.deepcopy(updated_game_state.get("players", []))
             action_ids = get_action_ids(updated_game_state.get("rules", {}))
             losing_player_nickname = next((event.get("player") for event in reversed(updated_game_state.get("history", [])) if event.get("action_id") == action_ids["lose_round"]), None)
-            losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
-            if losing_player:
-                losing_player["n_cards"] += 1
-                if losing_player["n_cards"] > updated_game_state["max_cards"]:
-                    losing_player["n_cards"] = 0
+            temp_players = update_n_cards(updated_game_state, losing_player_nickname)
             active_players_for_next_round = [p for p in temp_players if p.get("n_cards", 0) > 0]
             if len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round):
                 start_next_round(updated_game_state)

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -1,0 +1,95 @@
+import time
+import decimal
+import copy
+from shared.response import *
+from shared.db import table, get_from_dynamodb
+from shared.api_gateway import parse_event
+from shared.inputs import is_valid_uuid
+from shared.game import start_game, start_next_round, get_player_by_nickname, get_action_ids
+
+def update_in_dynamodb(game_uuid, players):
+    table.update_item(
+        Key={
+            'game_uuid': game_uuid
+        },
+        UpdateExpression="set players = :players, last_modified = :last_modified",
+        ExpressionAttributeValues={
+            ':players': players,
+            ':last_modified': decimal.Decimal(str(time.time()))
+        },
+        ReturnValues="NONE"
+    )
+    return True
+
+def lambda_handler(event, context):
+    try:
+        body = parse_event(event)
+        if not body:
+            return request_error_payload(event)
+
+        game_uuid = str(body.get("game_uuid"))
+        if not is_valid_uuid(game_uuid):
+            return parameter_error_payload("game_uuid", game_uuid, message="Invalid game UUID")
+
+        game = get_from_dynamodb(game_uuid)
+        if not game:
+            return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
+
+        player_uuid = str(body.get("player_uuid"))
+        if not is_valid_uuid(player_uuid):
+            return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
+
+        ready = body.get("ready")
+        if ready == 'True':
+            ready = True
+        elif ready == 'False':
+            ready = False
+        else:
+            return parameter_error_payload("ready", ready, message="Ready must be a boolean")
+
+        players = game.get("players")
+        player_found = False
+        for player in players:
+            if player["uuid"] == player_uuid:
+                player["ready"] = ready
+                player_found = True
+                break
+
+        if not player_found:
+            return parameter_error_payload("player_uuid", player_uuid, message="Player not found in this game")
+
+        game_status = game.get("status")
+        
+        if game_status == "Waiting for ready":
+            temp_players = copy.deepcopy(players)
+            action_ids = get_action_ids(game.get("rules", {}))
+            losing_player_nickname = None
+            for event in reversed(game.get("history", [])):
+                if event.get("action_id") == action_ids["lose_round"]:
+                    losing_player_nickname = event.get("player")
+                    break
+            losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
+            if losing_player:
+                losing_player["n_cards"] += 1
+                if losing_player["n_cards"] > game["max_cards"]:
+                    losing_player["n_cards"] = 0
+            active_players_for_next_round = [p for p in temp_players if p.get("n_cards", 0) > 0]
+        elif game_status == "Not started":
+            active_players_for_next_round = players
+
+        all_active_players_ready = len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round)
+
+        if all_active_players_ready:
+            if game_status == "Not started":
+                start_game(game)
+                return response_payload(200, {"message": "All players ready. Game started."})
+            elif game_status == "Waiting for ready":
+                start_next_round(game)
+                return response_payload(200, {"message": "All players ready. Next round started."})
+        else:
+            update_in_dynamodb(game_uuid, players)
+
+        return response_payload(200, {"message": "Readiness updated"})
+
+    except Exception as err:
+        return internal_error_payload(err)

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -60,6 +60,7 @@ def lambda_handler(event, context):
 
         game_status = game.get("status")
         
+        active_players_for_next_round = []
         if game_status == "Waiting for ready":
             temp_players = copy.deepcopy(players)
             action_ids = get_action_ids(game.get("rules", {}))
@@ -81,7 +82,9 @@ def lambda_handler(event, context):
 
         if all_active_players_ready:
             if game_status == "Not started":
-                start_game(game)
+                start_result = start_game(game)
+                if not start_result.get("success"):
+                    return error_payload(403, start_result.get("message"))
                 return response_payload(200, {"message": "All players ready. Game started."})
             elif game_status == "Waiting for ready":
                 start_next_round(game)

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -7,19 +7,20 @@ from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
 from shared.game import start_game, start_next_round, get_player_by_nickname, get_action_ids
 
-def update_in_dynamodb(game_uuid, players):
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set players = :players, last_modified = :last_modified",
+def update_player_readiness(game_uuid, player_index, ready_status):
+    """
+    Atomically updates a single player's readiness and returns the full, updated game state.
+    """
+    response = table.update_item(
+        Key={'game_uuid': game_uuid},
+        UpdateExpression=f"SET players[{player_index}].ready = :ready, last_modified = :last_modified",
         ExpressionAttributeValues={
-            ':players': players,
+            ':ready': ready_status,
             ':last_modified': decimal.Decimal(str(time.time()))
         },
-        ReturnValues="NONE"
+        ReturnValues="ALL_NEW"
     )
-    return True
+    return response.get('Attributes')
 
 def lambda_handler(event, context):
     try:
@@ -40,59 +41,44 @@ def lambda_handler(event, context):
             return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
 
         ready = body.get("ready")
-        if ready == 'True':
-            ready = True
-        elif ready == 'False':
-            ready = False
-        else:
+        if ready not in ['True', 'False']:
             return parameter_error_payload("ready", ready, message="Ready must be a boolean")
+        ready = True if ready == 'True' else False
 
         players = game.get("players")
-        player_found = False
-        for player in players:
+        player_index = -1
+        for i, player in enumerate(players):
             if player["uuid"] == player_uuid:
-                player["ready"] = ready
-                player_found = True
+                player_index = i
                 break
 
-        if not player_found:
+        if player_index == -1:
             return parameter_error_payload("player_uuid", player_uuid, message="Player not found in this game")
 
-        game_status = game.get("status")
-        
-        active_players_for_next_round = []
+        updated_game_state = update_player_readiness(game_uuid, player_index, ready)
+
+        game_status = updated_game_state.get("status")
         if game_status == "Waiting for ready":
-            temp_players = copy.deepcopy(players)
-            action_ids = get_action_ids(game.get("rules", {}))
-            losing_player_nickname = None
-            for event in reversed(game.get("history", [])):
-                if event.get("action_id") == action_ids["lose_round"]:
-                    losing_player_nickname = event.get("player")
-                    break
+            temp_players = copy.deepcopy(updated_game_state.get("players", []))
+            action_ids = get_action_ids(updated_game_state.get("rules", {}))
+            losing_player_nickname = next((event.get("player") for event in reversed(updated_game_state.get("history", [])) if event.get("action_id") == action_ids["lose_round"]), None)
             losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
             if losing_player:
                 losing_player["n_cards"] += 1
-                if losing_player["n_cards"] > game["max_cards"]:
+                if losing_player["n_cards"] > updated_game_state["max_cards"]:
                     losing_player["n_cards"] = 0
             active_players_for_next_round = [p for p in temp_players if p.get("n_cards", 0) > 0]
+            if len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round):
+                start_next_round(updated_game_state)
+                return response_payload(200, {"message": "All players ready. Next round started."})
         elif game_status == "Not started":
-            active_players_for_next_round = players
-
-        all_active_players_ready = len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round)
-
-        if all_active_players_ready:
-            if game_status == "Not started":
-                start_result = start_game(game)
+            players = updated_game_state.get("players", [])
+            if len(players) >= 2 and all(p.get("ready") for p in players):
+                start_result = start_game(updated_game_state)
                 if not start_result.get("success"):
                     return error_payload(403, start_result.get("message"))
                 return response_payload(200, {"message": "All players ready. Game started."})
-            elif game_status == "Waiting for ready":
-                start_next_round(game)
-                return response_payload(200, {"message": "All players ready. Next round started."})
-        else:
-            update_in_dynamodb(game_uuid, players)
-
-        return response_payload(200, {"message": "Readiness updated"})
+        return response_payload(200, {"message": "Readiness updated"}) # Shouldn't be reached
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -73,9 +73,7 @@ def lambda_handler(event, context):
         elif game_status == "Not started":
             players = updated_game_state.get("players", [])
             if len(players) >= 2 and all(p.get("ready") for p in players):
-                start_result = start_game(updated_game_state)
-                if not start_result.get("success"):
-                    return error_payload(403, start_result.get("message"))
+                start_game(updated_game_state)
                 return response_payload(200, {"message": "All players ready. Game started."})
         return response_payload(200, {"message": "Readiness updated"}) # Shouldn't be reached
 

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -4,6 +4,7 @@ import copy
 from shared.response import *
 from shared.db import table, get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus
 from shared.game import update_n_cards
 from shared.inputs import is_valid_uuid
 from shared.game import start_game, start_next_round, get_player_by_nickname, get_action_ids
@@ -62,7 +63,7 @@ def lambda_handler(event, context):
         updated_game_state = update_player_readiness(game_uuid, player_index, ready)
 
         game_status = updated_game_state.get("status")
-        if game_status == "Waiting for ready":
+        if game_status == GameStatus.WAITING_FOR_READY:
             action_ids = get_action_ids(updated_game_state.get("rules", {}))
             losing_player_nickname = next((event.get("player") for event in reversed(updated_game_state.get("history", [])) if event.get("action_id") == action_ids["lose_round"]), None)
             temp_players = update_n_cards(updated_game_state, losing_player_nickname)
@@ -70,7 +71,7 @@ def lambda_handler(event, context):
             if len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round):
                 start_next_round(updated_game_state)
                 return response_payload(200, {"message": "All players ready. Next round started."})
-        elif game_status == "Not started":
+        elif game_status == GameStatus.NOT_STARTED:
             players = updated_game_state.get("players", [])
             if len(players) >= 2 and all(p.get("ready") for p in players):
                 start_game(updated_game_state)

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -1,0 +1,63 @@
+from enum import Enum
+
+class GameStatus:
+    NOT_STARTED = "Not started"
+    RUNNING = "Running"
+    WAITING_FOR_READY = "Waiting for ready"
+    FINISHED = "Finished"
+
+class CommonCardsRules(Enum):
+    INCREASING = -1
+    SLOWLY_INCREASING = -2
+
+    @property
+    def rate(self):
+        if self == CommonCardsRules.INCREASING:
+            return 1/3
+        if self == CommonCardsRules.SLOWLY_INCREASING:
+            return 1/5
+        return 0
+
+    @classmethod
+    def special_values(cls):
+        return [item.value for item in cls]
+
+class _Range:
+    def __init__(self, bottom, top):
+        self.BOTTOM = bottom
+        self.TOP = top
+
+class RuleValues:
+    DECK_SIZES = (24, 32)
+    DECK_SIZE_DEFAULT = 24
+    JOKERS_RANGE = _Range(0, 12) # We don't envisage players needing more than 12
+    JOKERS_DEFAULT = 0
+    BLANKS_RANGE = _Range(0, 12) # We don't envisage players needing more than 12
+    BLANKS_DEFAULT = 0
+    
+    TIME_LIMIT_RANGE = _Range(1, 300) # We don't envisage players needing more than 5 minutes. Changing this might need a change in the SQS queue time limit
+    TIME_LIMIT_NO_LIMIT = 0
+    TIME_LIMIT_DEFAULT = TIME_LIMIT_NO_LIMIT
+
+    MAX_CARDS_FIXED_RANGE = _Range(1, 11)
+    MAX_CARDS_NO_PREFERENCE_API = 0
+    MAX_CARDS_NO_PREFERENCE_INTERNAL = None
+    MAX_CARDS_PREFERENCE_DEFAULT = MAX_CARDS_NO_PREFERENCE_INTERNAL
+
+    COMMON_CARDS_FIXED_RANGE = _Range(0, 12) # We don't envisage players needing more than 12
+    COMMON_CARDS_DEFAULT = 0
+    
+    @classmethod
+    def is_valid_time_limit_rule(cls, value):
+        """Checks if a value is a valid time limit rule."""
+        return (value == cls.TIME_LIMIT_NO_LIMIT) or (cls.TIME_LIMIT_RANGE.BOTTOM <= value <= cls.TIME_LIMIT_RANGE.TOP)
+
+    @classmethod
+    def is_valid_common_cards_rule(cls, value):
+        """Checks if a value is a valid common cards rule."""
+        return (value in CommonCardsRules.special_values()) or (cls.COMMON_CARDS_FIXED_RANGE.BOTTOM <= value <= cls.COMMON_CARDS_FIXED_RANGE.TOP)
+    
+    @classmethod
+    def is_valid_max_cards_rule(cls, value):
+        """Checks if a value is a valid max cards preference."""
+        return (value == cls.MAX_CARDS_NO_PREFERENCE_API) or (cls.MAX_CARDS_FIXED_RANGE.BOTTOM <= value <= cls.MAX_CARDS_FIXED_RANGE.TOP)

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -14,7 +14,9 @@ def get_from_dynamodb(game_uuid):
         return items[0]
     return None
 
-def save_in_dynamodb(obj):
+def save_in_dynamodb(obj, game_uuid=None):
+    if game_uuid:
+        obj['game_uuid'] = game_uuid
     obj["last_modified"] = decimal.Decimal(str(time.time()))
     table.put_item(Item=obj)
     return True

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -1,7 +1,9 @@
 import boto3
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 import decimal
 import time
+from .logging import logger
 
 dynamodb = boto3.resource('dynamodb')
 table = dynamodb.Table("games")
@@ -14,9 +16,59 @@ def get_from_dynamodb(game_uuid):
         return items[0]
     return None
 
-def save_in_dynamodb(obj, game_uuid=None):
+def save_in_dynamodb(obj, game_uuid=None, last_modified_condition=None):
     if game_uuid:
         obj['game_uuid'] = game_uuid
     obj["last_modified"] = decimal.Decimal(str(time.time()))
-    table.put_item(Item=obj)
-    return True
+
+    put_params = {'Item': obj}
+    if last_modified_condition:
+        put_params['ConditionExpression'] = "last_modified = :lm"
+        put_params['ExpressionAttributeValues'] = {':lm': last_modified_condition}
+
+    try:
+        table.put_item(**put_params)
+        return True
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            logger.warning(f"Conditional save failed for game_uuid: {obj.get('game_uuid')}.")
+            return False
+        else:
+            raise
+
+def transact_end_of_round(live_game_state, archive_game_state, last_modified_condition):
+    """
+    Atomically updates the live game state and saves the round archive using a transaction.
+    Returns True on success, False if the transaction fails due to a condition check.
+    """
+    try:
+        archive_game_state['last_modified'] = decimal.Decimal(str(time.time()))
+        live_game_state['last_modified'] = decimal.Decimal(str(time.time()))
+        
+        transact_items = [
+            {
+                'Put': {
+                    'TableName': table.name,
+                    'Item': live_game_state,
+                    'ConditionExpression': 'last_modified = :lm',
+                    'ExpressionAttributeValues': {':lm': last_modified_condition}
+                }
+            },
+            {
+                'Put': {
+                    'TableName': table.name,
+                    'Item': archive_game_state,
+                    'ConditionExpression': 'attribute_not_exists(game_uuid)'
+                }
+            }
+        ]
+        table.meta.client.transact_write_items(TransactItems=transact_items)
+        
+        return True
+
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'TransactionCanceledException':
+            logger.warning(f"End of round transaction failed for game {live_game_state['game_uuid']} due to a race condition.")
+            return False
+        else:
+            raise

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -187,10 +187,10 @@ def calculate_actual_max_cards(rules, n_players):
     if n_players < 2:
         return 0
     common_cards_rule = int(rules.get("common_cards", 0))
-    max_cards_preference = int(rules.get("max_cards_preference", 0))
+    max_cards_preference = rules.get("max_cards_preference", 0)
     total_deck_size = int(rules.get("deck_size", 24)) + int(rules.get("jokers", 0)) + int(rules.get("blanks", 0))
-    if max_cards_preference != 0:
-        return min(max_cards_preference, calculate_largest_feasible_max_cards_per_player(n_players, total_deck_size, common_cards_rule))
+    if max_cards_preference:
+        return min(int(max_cards_preference), calculate_largest_feasible_max_cards_per_player(n_players, total_deck_size, common_cards_rule))
     else:
         suggested_total_cards_in_round = calculate_suggested_max_cards_dealt_in_any_round(rules)
         return calculate_largest_feasible_max_cards_per_player(n_players, suggested_total_cards_in_round, common_cards_rule)

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -187,9 +187,9 @@ def calculate_actual_max_cards(rules, n_players):
     if n_players < 2:
         return 0
     common_cards_rule = int(rules.get("common_cards", 0))
-    max_cards_preference = int(rules.get("max_cards_preference", None))
+    max_cards_preference = int(rules.get("max_cards_preference", 0))
     total_deck_size = int(rules.get("deck_size", 24)) + int(rules.get("jokers", 0)) + int(rules.get("blanks", 0))
-    if max_cards_preference:
+    if max_cards_preference != 0:
         return min(max_cards_preference, calculate_largest_feasible_max_cards_per_player(n_players, total_deck_size, common_cards_rule))
     else:
         suggested_total_cards_in_round = calculate_suggested_max_cards_dealt_in_any_round(rules)

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -30,13 +30,11 @@ def find_next_active_player(players, cp_nickname):
     next_active_player = (active_players * 2)[current_player_order + 1]
     return next_active_player
 
-def censor_game(game, current_round, player_nickname=None):
-    revealed_hands = []
-    if game["status"] == "Finished":
-        revealed_hands = game["hands"]
-    elif game["round_number"] < current_round or game["status"] == "Waiting for ready":
+def censor_game(game, player_nickname=None):
+    lose_round_id = get_action_ids(game.get("rules", {}))["lose_round"]
+    if any(event.get("action_id") == lose_round_id for event in game.get("history", [])):
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"])]
-    elif player_nickname and game["round_number"] == current_round:
+    else:
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"]) and hand["nickname"] == player_nickname]
 
     private_players = []

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -150,26 +150,33 @@ def start_player_timer(game):
                 history_len
             )
 
+def calculate_max_cards(n_players, rules):
+    deck_size = int(rules.get("deck_size", 24))
+    common_cards_rule = int(rules.get("common_cards", 0))
+    n_jokers = int(rules.get("jokers", 0))
+
+    # Max cards calculation: maximum cards that can be dealt accounting for the common cards rule and number of players
+    # For nicer gameplay, jokers decrease max cards acting as if the deck was smaller, by 4 cards for the first joker and 2 for each next joker
+    # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
+    # x*n*(1+rate) < deck_size + (n*rate)  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
+    pretend_deck_size = deck_size
+    if n_jokers > 0:
+        pretend_deck_size -= (2 + 2 * n_jokers)
+    if common_cards_rule in (-1, -2):
+        rate = get_common_cards_rate_by_id(common_cards_rule)
+        max_cards = int((pretend_deck_size + n_players * rate) / (n_players * (1 + rate)) - 0.001)
+    else:
+        max_cards = int((pretend_deck_size - common_cards_rule) / n_players)
+    return max_cards if max_cards <= 11 else 11
+
 def start_game(game):
     game_uuid = game["game_uuid"]
     players = game["players"]
     rules = game.get("rules", {})
-    n_players = len(players)
-    deck_size = int(rules.get("deck_size", 24))
-    common_cards_rule = int(rules.get("common_cards", 0))
+    max_cards = calculate_max_cards(len(players), rules)
 
     for player in players:
         player["n_cards"] = 1
-
-    # Max cards calculation: maximum cards that can be dealt accounting for the common cards rule but excluding jokers and blanks
-    # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
-    # x*n*(1+rate) < deck_size + (n*rate)  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
-    if common_cards_rule in (-1, -2):
-        rate = get_common_cards_rate_by_id(common_cards_rule)
-        max_cards = int((deck_size + n_players * rate) / (n_players * (1 + rate)) - 0.001)
-    else:
-        max_cards = int((deck_size - common_cards_rule) / n_players)
-    if max_cards > 11: max_cards = 11
 
     public = "false"
     status = "Running"

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -322,8 +322,7 @@ def are_rules_unsupported_by_ai(rules):
         int(rules.get("deck_size", 24)) != 24 or
         int(rules.get("common_cards", 0)) != 0 or
         int(rules.get("jokers", 0)) != 0 or
-        int(rules.get("blanks", 0)) != 0 or
-        not rules.get("standard_order", True)
+        int(rules.get("blanks", 0)) != 0
     )
 
 def update_ai_readiness(players, rules):

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -30,7 +30,7 @@ def find_next_active_player(players, cp_nickname):
     next_active_player = (active_players * 2)[current_player_order + 1]
     return next_active_player
 
-def censor_game(game, current_round, player_nickname):
+def censor_game(game, current_round, player_nickname=None):
     revealed_hands = []
     if game["status"] == "Finished":
         revealed_hands = game["hands"]

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -63,12 +63,12 @@ def censor_game(game, current_round, player_authenticated, player_nickname):
 
 def calculate_common_cards(players, rules):
     common_cards_rule = int(rules.get("common_cards", 0))
-    if common_cards_rule == -1:
-        player_cards = [int(p.get("n_cards")) for p in players]
-        return min(n for n in player_cards if n>0)
+    if common_cards_rule in (-1, -2):
+        player_hand_sizes = [int(p.get("n_cards")) for p in players]
+        smallest_hand_size = min(n for n in player_hand_sizes if n>0)
+        return int((smallest_hand_size+1)/2) if common_cards_rule == -2 else smallest_hand_size
     else:
         return common_cards_rule
-
 
 def draw_cards(players, rules):
     """
@@ -157,7 +157,7 @@ def start_game(game):
     num_common_cards = calculate_common_cards(players, rules)
 
     numerator = deck_size - num_common_cards if common_cards_rule > 0 else deck_size
-    denominator = n_players + 1 if common_cards_rule == -1 else n_players
+    denominator = n_players + 1 if common_cards_rule in (-1, -2) else n_players
     max_cards = floor(numerator / denominator)
     if max_cards > 11: max_cards = 11
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -58,7 +58,9 @@ def censor_game(game, current_round, player_authenticated, player_nickname):
         "cp_nickname": game["cp_nickname"],
         "history": game["history"],
         "last_modified": game["last_modified"],
-        "rules": game.get("rules", {})
+        "rules": game.get("rules", {}),
+        "move_deadline": game.get("move_deadline"),
+        "update_time": time.time()
     }
 
 def get_common_cards_rate_by_id(rule):
@@ -131,7 +133,10 @@ def arrange_players(players):
     return final_players
 
 def start_player_timer(game):
-    """Checks for a time limit and sends an SQS message if active."""
+    """
+    Checks for a time limit, sends an SQS message if active,
+    and returns the calculated move deadline.
+    """
     rules = game.get("rules", {})
     time_limit = int(rules.get("time_limit", 0))
     logger.info(f"## Checking for game {game.get('game_uuid')}")
@@ -141,7 +146,6 @@ def start_player_timer(game):
         player_to_time = get_player_by_nickname(game.get("players", []), game.get("cp_nickname"))
         if player_to_time:
             history_len = len(game.get("history", []))
-            logger.info(f"START_PLAYER_TIMER: Scheduling timeout for {player_to_time['nickname']} with history length {history_len}")
             send_time_limit_message(
                 game["game_uuid"],
                 player_to_time["uuid"],
@@ -149,6 +153,8 @@ def start_player_timer(game):
                 time_limit,
                 history_len
             )
+            return decimal.Decimal(str(time.time() + time_limit))
+    return None
 
 def calculate_max_cards(n_players, rules):
     deck_size = int(rules.get("deck_size", 24))
@@ -158,7 +164,7 @@ def calculate_max_cards(n_players, rules):
     # Max cards calculation: maximum cards that can be dealt accounting for the common cards rule and number of players
     # For nicer gameplay, jokers decrease max cards acting as if the deck was smaller, by 4 cards for the first joker and 2 for each next joker
     # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
-    # x*n*(1+rate) < deck_size + (n*rate)  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
+    # x*n*(1+rate) < deck_size + n*rate  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
     pretend_deck_size = deck_size
     if n_jokers > 0:
         pretend_deck_size -= (2 + 2 * n_jokers)
@@ -186,9 +192,13 @@ def start_game(game):
     hands, common_hand = draw_cards(players, rules)
     cp_nickname = players[0]["nickname"]
 
+    game['round_number'] = round_number
+    game['cp_nickname'] = cp_nickname
+    move_deadline = start_player_timer(game)
+
     table.update_item(
         Key={'game_uuid': game_uuid},
-        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, max_cards = :max_cards, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname",
+        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, max_cards = :max_cards, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
         ExpressionAttributeValues={
             ':last_modified': decimal.Decimal(str(time.time())),
             ':players': players,
@@ -198,17 +208,14 @@ def start_game(game):
             ':max_cards': max_cards,
             ':hands': hands,
             ':common_hand': common_hand,
-            ':cp_nickname': cp_nickname
+            ':cp_nickname': cp_nickname,
+            ':move_deadline': move_deadline
         },
         ExpressionAttributeNames={
             '#game_public': "public",
             '#game_status': "status"
         }
     )
-
-    game['round_number'] = round_number
-    game['cp_nickname'] = cp_nickname
-    start_player_timer(game)
     return True
 
 def start_next_round(game):
@@ -243,9 +250,10 @@ def start_next_round(game):
     game["round_number"] += 1
     game["history"] = []
     game["hands"], game["common_hand"] = draw_cards(game["players"], game.get("rules", {}))
-    save_in_dynamodb(game)
     
-    start_player_timer(game)
+    game["move_deadline"] = start_player_timer(game)
+    
+    save_in_dynamodb(game)
     return True
 
 def get_action_ids(rules):
@@ -265,6 +273,7 @@ def end_round(game, losing_player_nickname):
     action_ids = get_action_ids(game.get("rules", {}))
     game["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
     game["cp_nickname"] = None
+    game["move_deadline"] = None
     end_of_round_state = copy.deepcopy(game)
     save_in_dynamodb(end_of_round_state, f"{end_of_round_state['game_uuid']}_{int(end_of_round_state['round_number'])}")
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -7,6 +7,7 @@ import copy
 from .db import table, save_in_dynamodb, transact_end_of_round
 from .time_limit import send_time_limit_message
 from .logging import logger
+from .constants import GameStatus, CommonCardsRules, RuleValues
 
 def get_player_by_nickname(players, nickname):
     filtered_players = [p for p in players if p["nickname"] == nickname]
@@ -59,19 +60,12 @@ def censor_game(game, player_nickname=None):
         "update_time": time.time()
     }
 
-def get_common_cards_rate_by_id(rule):
-    if rule == -2:
-        return 1/5
-    if rule == -1:
-        return 1/3
-    return False
-
 def calculate_common_cards(players, rules):
-    common_cards_rule = int(rules.get("common_cards", 0))
-    if common_cards_rule in (-1, -2):
+    common_cards_rule = int(rules.get("common_cards", RuleValues.COMMON_CARDS_DEFAULT))
+    if common_cards_rule in (CommonCardsRules.INCREASING.value, CommonCardsRules.SLOWLY_INCREASING.value):
+        rule_enum = CommonCardsRules(common_cards_rule)
         extra_cards_per_hand = [hs-1 for hs in [int(p.get("n_cards")) for p in players] if hs>0]
-        rate = get_common_cards_rate_by_id(common_cards_rule)
-        return int(1 + sum(extra_cards_per_hand) * rate)
+        return int(1 + sum(extra_cards_per_hand) * rule_enum.rate)
     else:
         return common_cards_rule
 
@@ -79,9 +73,9 @@ def draw_cards(players, rules):
     """
     Draws cards for players and common cards based on the provided rules.
     """
-    deck_size = rules.get("deck_size", 24)
-    num_jokers = int(rules.get("jokers", 0))
-    num_blanks = int(rules.get("blanks", 0))
+    deck_size = rules.get("deck_size", RuleValues.DECK_SIZE_DEFAULT)
+    num_jokers = int(rules.get("jokers", RuleValues.JOKERS_DEFAULT))
+    num_blanks = int(rules.get("blanks", RuleValues.BLANKS_DEFAULT))
     num_common_cards = calculate_common_cards(players, rules)
 
     if deck_size == 32:
@@ -134,7 +128,7 @@ def start_player_timer(game):
     and returns the calculated move deadline.
     """
     rules = game.get("rules", {})
-    time_limit = int(rules.get("time_limit", 0))
+    time_limit = int(rules.get("time_limit", RuleValues.TIME_LIMIT_NO_LIMIT))
     logger.info(f"## Checking for game {game.get('game_uuid')}")
     logger.info(f"## Time limit rule is {time_limit} and current player is {game.get('cp_nickname')}")
     
@@ -159,9 +153,9 @@ def calculate_suggested_max_cards_dealt_in_any_round(rules):
     Computes the expanded deck size and applies a downward adjustment for jokers. 
     Always caps the final result at base deck size to not prolong the game
     """
-    base_deck_size = int(rules.get("deck_size", 24))
-    jokers = int(rules.get("jokers", 0))
-    blanks = int(rules.get("blanks", 0))
+    base_deck_size = int(rules.get("deck_size", RuleValues.DECK_SIZE_DEFAULT))
+    jokers = int(rules.get("jokers", RuleValues.JOKERS_DEFAULT))
+    blanks = int(rules.get("blanks", RuleValues.BLANKS_DEFAULT))
     if jokers > 0:
         suggested_total = (base_deck_size + blanks + jokers) / (1 + 0.2 * (jokers + 1))
         return min(floor(suggested_total), base_deck_size)
@@ -174,8 +168,8 @@ def calculate_largest_feasible_max_cards_per_player(n_players, total_cards_in_pl
     # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
     # x*n*(1+rate) < deck_size + n*rate  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
 
-    if common_cards_rule in (-1, -2):
-        rate = get_common_cards_rate_by_id(common_cards_rule)
+    if common_cards_rule in CommonCardsRules.special_values():
+        rate = CommonCardsRules(common_cards_rule).rate
         # Formula rearranged to solve for x (max_cards): x <= (total_cards - 1 + n*rate) / (n * (1 + rate))
         max_cards = (total_cards_in_play + n_players * rate) / (n_players * (1 + rate)) - 0.001
         return min(floor(max_cards), 11)
@@ -186,9 +180,9 @@ def calculate_largest_feasible_max_cards_per_player(n_players, total_cards_in_pl
 def calculate_actual_max_cards(rules, n_players):
     if n_players < 2:
         return 0
-    common_cards_rule = int(rules.get("common_cards", 0))
-    max_cards_preference = rules.get("max_cards_preference", 0)
-    total_deck_size = int(rules.get("deck_size", 24)) + int(rules.get("jokers", 0)) + int(rules.get("blanks", 0))
+    common_cards_rule = int(rules.get("common_cards", RuleValues.COMMON_CARDS_DEFAULT))
+    max_cards_preference = rules.get("max_cards_preference", RuleValues.MAX_CARDS_NO_PREFERENCE_INTERNAL)
+    total_deck_size = int(rules.get("deck_size", RuleValues.DECK_SIZE_DEFAULT)) + int(rules.get("jokers", RuleValues.JOKERS_DEFAULT)) + int(rules.get("blanks", RuleValues.BLANKS_DEFAULT))
     if max_cards_preference:
         return min(int(max_cards_preference), calculate_largest_feasible_max_cards_per_player(n_players, total_deck_size, common_cards_rule))
     else:
@@ -204,7 +198,7 @@ def start_game(game):
         player["n_cards"] = 1
 
     public = "false"
-    status = "Running"
+    status = GameStatus.RUNNING
     round_number = 1
     
     players = arrange_players(players)
@@ -256,7 +250,7 @@ def start_next_round(game):
         game["cp_nickname"] = losing_player["nickname"]
 
     # Set up and save the next round
-    game["status"] = "Running"
+    game["status"] = GameStatus.RUNNING
     game["round_number"] += 1
     game["history"] = []
     game["hands"], game["common_hand"] = draw_cards(game["players"], game.get("rules", {}))
@@ -270,7 +264,7 @@ def get_action_ids(rules):
     """
     Returns a dictionary of key action IDs based on the deck size.
     """
-    deck_size = rules.get("deck_size", 24)
+    deck_size = rules.get("deck_size", RuleValues.DECK_SIZE_DEFAULT)
     if deck_size == 32:
         return {"check": 140, "lose_round": 141}
     return {"check": 88, "lose_round": 89}
@@ -282,7 +276,7 @@ def end_round(game, losing_player_nickname):
     """
     original_last_modified = game.get("last_modified")
     action_ids = get_action_ids(game.get("rules", {}))
-    time_limit = int(game.get("rules", {}).get("time_limit", 0))
+    time_limit = int(game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_NO_LIMIT))
 
     game["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
     game["cp_nickname"] = None
@@ -298,13 +292,13 @@ def end_round(game, losing_player_nickname):
     
     if sum(1 for p in temp_players if p.get("n_cards", 0) > 0) <= 1:
         # Game is finished
-        game["status"] = "Finished"
+        game["status"] = GameStatus.FINISHED
         game["players"] = temp_players # Use the updated player list
         if transact_end_of_round(game, archive_state, original_last_modified):
             return archive_state
     elif time_limit > 0 and any(p for p in game["players"] if p.get("n_cards") > 0 and not p.get("ai_agent")):
         # Game is timed and waiting for human players' readiness
-        game["status"] = "Waiting for ready"
+        game["status"] = GameStatus.WAITING_FOR_READY
         game["players"] = unset_human_readiness(game["players"])
         if transact_end_of_round(game, archive_state, original_last_modified):
             return game
@@ -349,7 +343,7 @@ def is_update_redundant(game):
     Detects game state updates that are duplicates or will be obsolete within milliseconds
     """
     is_snapshot = "_" in game.get("game_uuid", "")
-    is_timed_game = game.get("rules", {}).get("time_limit", 0) > 0
+    is_timed_game = game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_NO_LIMIT) != RuleValues.TIME_LIMIT_NO_LIMIT
     losing_player_nickname = find_losing_player_nickname(game)
 
     # At the end of timed rounds, the archival snapshot and the live state are the same, so skip the snapshot.
@@ -361,7 +355,7 @@ def is_update_redundant(game):
     
     # When the last player gets ready, the game state will be updated but the next round will start immediately.
     # This makes the state with every player ready obsolete within milliseconds
-    if is_timed_game and losing_player_nickname and not game.get("status") == "Finished":
+    if is_timed_game and losing_player_nickname and not game.get("status") == GameStatus.FINISHED:
         if all(p.get("ready", False) for p in game.get("players", [])):
             return True
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -350,12 +350,12 @@ def is_update_redundant(game):
     # Except in the last round, where the live state shows the finished game information
     if is_snapshot and is_timed_game and losing_player_nickname:
         updated_players = update_n_cards(game, losing_player_nickname)
-        if sum(1 for p in updated_players if p.get("n_cards", 0) > 0) <= 1:
+        if sum(1 for p in updated_players if p.get("n_cards", 0) > 0) > 1:
             return True
     
     # When the last player gets ready, the game state will be updated but the next round will start immediately.
     # This makes the state with every player ready obsolete within milliseconds
-    if is_timed_game and losing_player_nickname and not game.get("status") == GameStatus.FINISHED:
+    if not is_snapshot and is_timed_game and losing_player_nickname and not game.get("status") == GameStatus.FINISHED:
         if all(p.get("ready", False) for p in game.get("players", [])):
             return True
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -30,18 +30,14 @@ def find_next_active_player(players, cp_nickname):
     next_active_player = (active_players * 2)[current_player_order + 1]
     return next_active_player
 
-def get_revealed_hands(game, current_round, current_status, player_authenticated, player_nickname):
+def censor_game(game, current_round, player_nickname):
     revealed_hands = []
-    if current_status == "Finished":
+    if game["status"] == "Finished":
         revealed_hands = game["hands"]
-    elif game["round_number"] < current_round or current_status == "Waiting for ready":
+    elif game["round_number"] < current_round or game["status"] == "Waiting for ready":
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"])]
-    elif player_authenticated and game["round_number"] == current_round:
+    elif player_nickname and game["round_number"] == current_round:
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"]) and hand["nickname"] == player_nickname]
-    return revealed_hands
-
-def censor_game(game, current_round, player_authenticated, player_nickname):
-    revealed_hands = get_revealed_hands(game, current_round, game["status"], player_authenticated, player_nickname)
 
     private_players = []
     for player in game["players"]:

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -241,17 +241,9 @@ def start_next_round(game):
     Recalls the loser of the previous round, updates cards,
     and starts the next round with the correct current player.
     """
-    action_ids = get_action_ids(game.get("rules", {}))
-    losing_player_nickname = None
-    # Find the loser from the history
-    for event in reversed(game.get("history", [])):
-        if event.get("action_id") == action_ids["lose_round"]:
-            losing_player_nickname = event.get("player")
-            break
-    
-    losing_player = get_player_by_nickname(game["players"], losing_player_nickname)
-
     # Update the card counts for the new round
+    losing_player_nickname = find_losing_player_nickname(game)    
+    losing_player = get_player_by_nickname(game["players"], losing_player_nickname)
     if losing_player:
         losing_player["n_cards"] += 1
         if losing_player["n_cards"] > game["max_cards"]:
@@ -343,19 +335,34 @@ def update_n_cards(game, losing_player_nickname):
     return temp_players
 
 
-def was_this_the_last_round(game_state):
-    """
-    Detects if this is a finished round after which there will be no more rounds.
-    """
-    action_ids = get_action_ids(game_state.get("rules", {}))
+def find_losing_player_nickname(game):
+    action_ids = get_action_ids(game.get("rules", {}))
     losing_player_nickname = None
-    for event in reversed(game_state.get("history", [])):
+    for event in reversed(game.get("history", [])):
         if event.get("action_id") == action_ids["lose_round"]:
             losing_player_nickname = event.get("player")
             break
+    return losing_player_nickname
 
-    if not losing_player_nickname:
-        return False
+def is_update_redundant(game):
+    """
+    Detects game state updates that are duplicates or will be obsolete within milliseconds
+    """
+    is_snapshot = "_" in game.get("game_uuid", "")
+    is_timed_game = game.get("rules", {}).get("time_limit", 0) > 0
+    losing_player_nickname = find_losing_player_nickname(game)
 
-    updated_players = update_n_cards(game_state, losing_player_nickname)
-    return sum(1 for p in updated_players if p.get("n_cards", 0) > 0) <= 1
+    # At the end of timed rounds, the archival snapshot and the live state are the same, so skip the snapshot.
+    # Except in the last round, where the live state shows the finished game information
+    if is_snapshot and is_timed_game and losing_player_nickname:
+        updated_players = update_n_cards(game, losing_player_nickname)
+        if sum(1 for p in updated_players if p.get("n_cards", 0) > 0) <= 1:
+            return True
+    
+    # When the last player gets ready, the game state will be updated but the next round will start immediately.
+    # This makes the state with every player ready obsolete within milliseconds
+    if is_timed_game and losing_player_nickname and not game.get("status") == "Finished":
+        if all(p.get("ready", False) for p in game.get("players", [])):
+            return True
+
+    return False

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -64,7 +64,8 @@ def censor_game(game, current_round, player_authenticated, player_nickname):
 def calculate_common_cards(players, rules):
     common_cards_rule = int(rules.get("common_cards", 0))
     if common_cards_rule == -1:
-        return min(int(p.get("n_cards", 1)) for p in players)
+        player_cards = [int(p.get("n_cards")) for p in players]
+        return min(n for n in player_cards if n>0)
     else:
         return common_cards_rule
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -155,7 +155,7 @@ def start_player_timer(game):
     return None
 
 
-def calculate_suggested_cards_in_round(rules):
+def calculate_suggested_max_cards_dealt_in_any_round(rules):
     """
     Calculates the suggested total number of cards to be in play for optimal experience.
     Computes the expanded deck size and applies a downward adjustment for jokers. 
@@ -171,7 +171,7 @@ def calculate_suggested_cards_in_round(rules):
         return base_deck_size
         
 
-def calculate_max_cards_per_player(n_players, total_cards_in_play, common_cards_rule):
+def calculate_largest_allowed_max_cards_per_player(n_players, total_cards_in_play, common_cards_rule):
     """Calculates the theoretical maximum number of cards a single player can hold."""
     # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
     # x*n*(1+rate) < deck_size + n*rate  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
@@ -199,10 +199,10 @@ def start_game(game):
     common_cards_rule = int(rules.get("common_cards", 0))
 
     if custom_max_cards == 0: # Auto-calculate
-        suggested_total = calculate_suggested_cards_in_round(rules)
-        max_cards = calculate_max_cards_per_player(n_players, suggested_total, common_cards_rule)
+        suggested_total = calculate_suggested_max_cards_dealt_in_any_round(rules)
+        max_cards = calculate_largest_allowed_max_cards_per_player(n_players, suggested_total, common_cards_rule)
     else: # Validate and use custom value
-        theoretical_max = calculate_max_cards_per_player(n_players, deck_size + jokers + blanks, common_cards_rule)
+        theoretical_max = calculate_largest_allowed_max_cards_per_player(n_players, deck_size + jokers + blanks, common_cards_rule)
         if custom_max_cards > theoretical_max:
             return {
                 "success": False,

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -4,10 +4,21 @@ from math import floor
 import time
 import decimal
 import copy
+import uuid
 from .db import table, save_in_dynamodb, transact_end_of_round
 from .time_limit import send_time_limit_message
 from .logging import logger
 from .constants import GameStatus, CommonCardsRules, RuleValues
+
+def create_player(game, nickname):
+    players = game.get("players")
+    ready = False if len(players) == 0 or game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_DEFAULT) != RuleValues.TIME_LIMIT_NO_LIMIT else True
+    return {
+        "uuid": str(uuid.uuid4()), 
+        "nickname": nickname, 
+        "n_cards": 0, 
+        "ready": ready
+    }
 
 def get_player_by_nickname(players, nickname):
     filtered_players = [p for p in players if p["nickname"] == nickname]

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -169,7 +169,7 @@ def calculate_suggested_max_cards_dealt_in_any_round(rules):
         return base_deck_size
         
 
-def calculate_largest_allowed_max_cards_per_player(n_players, total_cards_in_play, common_cards_rule):
+def calculate_largest_feasible_max_cards_per_player(n_players, total_cards_in_play, common_cards_rule):
     """Calculates the theoretical maximum number of cards a single player can hold."""
     # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
     # x*n*(1+rate) < deck_size + n*rate  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
@@ -183,32 +183,22 @@ def calculate_largest_allowed_max_cards_per_player(n_players, total_cards_in_pla
         max_cards = (total_cards_in_play - common_cards_rule) / n_players
         return min(floor(max_cards), 11)
 
+def calculate_actual_max_cards(rules, n_players):
+    if n_players < 2:
+        return 0
+    common_cards_rule = int(rules.get("common_cards", 0))
+    max_cards_preference = int(rules.get("max_cards_preference", None))
+    total_deck_size = int(rules.get("deck_size", 24)) + int(rules.get("jokers", 0)) + int(rules.get("blanks", 0))
+    if max_cards_preference:
+        return min(max_cards_preference, calculate_largest_feasible_max_cards_per_player(n_players, total_deck_size, common_cards_rule))
+    else:
+        suggested_total_cards_in_round = calculate_suggested_max_cards_dealt_in_any_round(rules)
+        return calculate_largest_feasible_max_cards_per_player(n_players, suggested_total_cards_in_round, common_cards_rule)
+
 def start_game(game):
     game_uuid = game["game_uuid"]
     players = game["players"]
     rules = game.get("rules", {})
-    n_players = len(players)
-
-    # Determine the final max_cards value
-    custom_max_cards = int(game.get("max_cards", 0))
-    deck_size = int(rules.get("deck_size", 24))
-    jokers = int(rules.get("jokers", 0))
-    blanks = int(rules.get("blanks", 0))
-    common_cards_rule = int(rules.get("common_cards", 0))
-
-    if custom_max_cards == 0: # Auto-calculate
-        suggested_total = calculate_suggested_max_cards_dealt_in_any_round(rules)
-        max_cards = calculate_largest_allowed_max_cards_per_player(n_players, suggested_total, common_cards_rule)
-    else: # Validate and use custom value
-        theoretical_max = calculate_largest_allowed_max_cards_per_player(n_players, deck_size + jokers + blanks, common_cards_rule)
-        if custom_max_cards > theoretical_max:
-            return {
-                "success": False,
-                "error": "MAX_CARDS_TOO_HIGH",
-                "message": f"With {n_players} players, max cards cannot exceed {theoretical_max}. Please adjust rules."
-            }
-        else:
-            max_cards = custom_max_cards
 
     for player in players:
         player["n_cards"] = 1
@@ -227,14 +217,13 @@ def start_game(game):
 
     table.update_item(
         Key={'game_uuid': game_uuid},
-        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, max_cards = :max_cards, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
+        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
         ExpressionAttributeValues={
             ':last_modified': decimal.Decimal(str(time.time())),
             ':players': players,
             ':public': public,
             ':status': status,
             ':round_number': round_number,
-            ':max_cards': max_cards,
             ':hands': hands,
             ':common_hand': common_hand,
             ':cp_nickname': cp_nickname,
@@ -245,7 +234,7 @@ def start_game(game):
             '#game_status': "status"
         }
     )
-    return {"success": True}
+    return True
 
 def start_next_round(game):
     """

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -370,25 +370,3 @@ def is_game_about_to_finish(game_state):
 
     active_players = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
     return active_players <= 1
-
-def are_rules_unsupported_by_ai(rules):
-    """
-    Hopefully temporary O_O.
-    """
-    return (
-        int(rules.get("deck_size", 24)) != 24 or
-        int(rules.get("common_cards", 0)) != 0 or
-        int(rules.get("jokers", 0)) != 0 or
-        int(rules.get("blanks", 0)) != 0
-    )
-
-def update_ai_readiness(players, rules):
-    """
-    Updates the readiness of AI players based on the complexity of game rules.
-    Human player readiness is unaffected.
-    """
-    rules_are_unsupported = are_rules_unsupported_by_ai(rules)
-    for player in players:
-        if player.get("ai_agent"):
-            player["ready"] = not rules_are_unsupported
-    return players

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -1,5 +1,12 @@
-from random import sample
+from random import sample, shuffle, choice
 from itertools import islice, product
+from math import floor
+import time
+import decimal
+import copy
+from .db import table, save_in_dynamodb
+from .time_limit import send_time_limit_message
+from .logging import logger
 
 def get_player_by_nickname(players, nickname):
     filtered_players = [p for p in players if p["nickname"] == nickname]
@@ -17,9 +24,15 @@ def is_active_player(players, nickname):
         return player["n_cards"] != 0
     return False
 
+def find_next_active_player(players, cp_nickname):
+    active_players = [player for player in players if player["n_cards"] != 0 or player["nickname"] == cp_nickname]
+    current_player_order = [i for i, player in enumerate(active_players) if player["nickname"] == cp_nickname][0]
+    next_active_player = (active_players * 2)[current_player_order + 1]
+    return next_active_player
+
 def get_revealed_hands(game, current_round, current_status, player_authenticated, player_nickname):
     revealed_hands = []
-    if game["round_number"] < current_round or current_status == "Finished":
+    if game["round_number"] < current_round or current_status in ["Finished", "Waiting for ready"]:
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"])]
     elif player_authenticated and game["round_number"] == current_round:
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"]) and hand["nickname"] == player_nickname]
@@ -41,18 +54,261 @@ def censor_game(game, current_round, player_authenticated, player_nickname):
         "max_cards": game["max_cards"],
         "players": private_players,
         "hands": revealed_hands,
+        "common_hand": game.get("common_hand", []),
         "cp_nickname": game["cp_nickname"],
         "history": game["history"],
-        "last_modified": game["last_modified"]
+        "last_modified": game["last_modified"],
+        "rules": game.get("rules", {})
     }
 
-def draw_cards(players):
-    possible_cards = product(range(6), range(4))
-    all_cards_raw = sample(list(possible_cards), sum(int(p["n_cards"]) for p in players))
+def calculate_common_cards(players, rules):
+    common_cards_rule = int(rules.get("common_cards", 0))
+    if common_cards_rule == -1:
+        return min(int(p.get("n_cards", 1)) for p in players)
+    else:
+        return common_cards_rule
+
+
+def draw_cards(players, rules):
+    """
+    Draws cards for players and common cards based on the provided rules.
+    """
+    deck_size = rules.get("deck_size", 24)
+    num_jokers = int(rules.get("jokers", 0))
+    num_blanks = int(rules.get("blanks", 0))
+    num_common_cards = calculate_common_cards(players, rules)
+
+    if deck_size == 32:
+        possible_cards = product(range(8), range(4))
+    else:
+        possible_cards = product(range(6), range(4))
+
+    full_deck_raw = list(possible_cards)
+    full_deck_raw.extend([(-1, -1)] * num_jokers)
+    full_deck_raw.extend([(-2, -2)] * num_blanks)
+    
+    total_cards_to_deal = sum(int(p["n_cards"]) for p in players) + num_common_cards
+    all_cards_raw = sample(full_deck_raw, total_cards_to_deal)
+
     all_cards = [{"value": tup[0], "colour": tup[1]} for tup in all_cards_raw]
     card_iterator = iter(all_cards)
     hands = []
     for player in players:
         player_hand = list(islice(card_iterator, 0, int(player["n_cards"])))
         hands.append({"nickname": player['nickname'], "hand": player_hand})
-    return hands
+
+    common_hand = list(islice(card_iterator, 0, num_common_cards))
+    return hands, common_hand
+
+def arrange_players(players):
+    num_total = len(players)
+    num_ais = sum(1 for p in players if p.get("ai_agent"))
+    if num_ais == 0:
+        shuffle(players)
+        return players
+        
+    offset = choice(range(num_total))
+    ai_positions_from_zero = [floor(i * num_total / num_ais) for i in range(num_ais)]
+    ai_positions = [(i + offset) % num_total for i in ai_positions_from_zero]
+    ai_players = [p for p in players if p.get("ai_agent")]
+    human_players = [p for p in players if not p.get("ai_agent")]
+    shuffle(human_players)
+    
+    final_players = []
+    for i in range(num_total):
+        if i in ai_positions and ai_players:
+            final_players.append(ai_players.pop(0))
+        elif human_players:
+            final_players.append(human_players.pop(0))
+    return final_players
+
+def start_player_timer(game):
+    """Checks for a time limit and sends an SQS message if active."""
+    rules = game.get("rules", {})
+    time_limit = int(rules.get("time_limit", 0))
+    logger.info(f"## Checking for game {game.get('game_uuid')}")
+    logger.info(f"## Time limit rule is {time_limit} and current player is {game.get('cp_nickname')}")
+    
+    if time_limit > 0 and game.get("cp_nickname"):
+        player_to_time = get_player_by_nickname(game.get("players", []), game.get("cp_nickname"))
+        if player_to_time:
+            history_len = len(game.get("history", []))
+            logger.info(f"START_PLAYER_TIMER: Scheduling timeout for {player_to_time['nickname']} with history length {history_len}")
+            send_time_limit_message(
+                game["game_uuid"],
+                player_to_time["uuid"],
+                game["round_number"],
+                time_limit,
+                history_len
+            )
+
+def start_game(game):
+    game_uuid = game["game_uuid"]
+    players = game["players"]
+    rules = game.get("rules", {})
+    n_players = len(players)
+    deck_size = rules.get("deck_size", 24)
+    common_cards_rule = int(rules.get("common_cards", 0))
+
+    for player in players:
+        player["n_cards"] = 1
+
+    num_common_cards = calculate_common_cards(players, rules)
+
+    numerator = deck_size - num_common_cards if common_cards_rule > 0 else deck_size
+    denominator = n_players + 1 if common_cards_rule == -1 else n_players
+    max_cards = floor(numerator / denominator)
+    if max_cards > 11: max_cards = 11
+
+    public = "false"
+    status = "Running"
+    round_number = 1
+    
+    players = arrange_players(players)
+    hands, common_hand = draw_cards(players, rules)
+    cp_nickname = players[0]["nickname"]
+
+    table.update_item(
+        Key={'game_uuid': game_uuid},
+        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, max_cards = :max_cards, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname",
+        ExpressionAttributeValues={
+            ':last_modified': decimal.Decimal(str(time.time())),
+            ':players': players,
+            ':public': public,
+            ':status': status,
+            ':round_number': round_number,
+            ':max_cards': max_cards,
+            ':hands': hands,
+            ':common_hand': common_hand,
+            ':cp_nickname': cp_nickname
+        },
+        ExpressionAttributeNames={
+            '#game_public': "public",
+            '#game_status': "status"
+        }
+    )
+
+    game['round_number'] = round_number
+    game['cp_nickname'] = cp_nickname
+    start_player_timer(game)
+    return True
+
+def start_next_round(game):
+    """
+    Recalls the loser of the previous round, updates cards,
+    and starts the next round with the correct current player.
+    """
+    action_ids = get_action_ids(game.get("rules", {}))
+    losing_player_nickname = None
+    # Find the loser from the history
+    for event in reversed(game.get("history", [])):
+        if event.get("action_id") == action_ids["lose_round"]:
+            losing_player_nickname = event.get("player")
+            break
+    
+    losing_player = get_player_by_nickname(game["players"], losing_player_nickname)
+
+    # Update the card counts for the new round
+    if losing_player:
+        losing_player["n_cards"] += 1
+        if losing_player["n_cards"] > game["max_cards"]:
+            losing_player["n_cards"] = 0 # Player is now eliminated
+    
+    # Set the next player
+    if losing_player["n_cards"] == 0:
+        game["cp_nickname"] = find_next_active_player(game["players"], losing_player_nickname)["nickname"]
+    else:
+        game["cp_nickname"] = losing_player["nickname"]
+
+    # Set up and save the next round
+    game["status"] = "Running"
+    game["round_number"] += 1
+    game["history"] = []
+    game["hands"], game["common_hand"] = draw_cards(game["players"], game.get("rules", {}))
+    save_in_dynamodb(game)
+    
+    start_player_timer(game)
+    return True
+
+def get_action_ids(rules):
+    """
+    Returns a dictionary of key action IDs based on the deck size.
+    """
+    deck_size = rules.get("deck_size", 24)
+    if deck_size == 32:
+        return {"check": 140, "lose_round": 141}
+    return {"check": 88, "lose_round": 89}
+
+def end_round(game, losing_player_nickname):
+    """
+    Handles all the logic for ending a round. If a time limit is active,
+    it puts the game into a "Waiting for ready" state instead of starting the next round.
+    """
+    action_ids = get_action_ids(game.get("rules", {}))
+    game["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
+    game["cp_nickname"] = None
+    end_of_round_state = copy.deepcopy(game)
+    save_in_dynamodb(end_of_round_state, f"{end_of_round_state['game_uuid']}_{int(end_of_round_state['round_number'])}")
+
+    # Check for game end condition *before* altering the live state
+    temp_players = copy.deepcopy(game["players"])
+    temp_losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
+    temp_losing_player["n_cards"] += 1
+    if temp_losing_player["n_cards"] > game["max_cards"]:
+        temp_losing_player["n_cards"] = 0
+    
+    active_players = sum(1 for p in temp_players if p["n_cards"] > 0)
+    if active_players <= 1:
+        game["status"] = "Finished"
+        game["players"] = temp_players
+        save_in_dynamodb(game)
+        return end_of_round_state
+
+    # If game is not over, decide the next step
+    active_human_players = [p for p in temp_players if p.get("n_cards") > 0 and not p.get("ai_agent")]
+    time_limit = int(game.get("rules", {}).get("time_limit", 0))
+    if time_limit > 0 and active_human_players:
+        game["status"] = "Waiting for ready"
+        game["players"] = unset_human_readiness(game["players"])
+        save_in_dynamodb(game)
+        return game # For timed games, return the waiting state
+    else:
+        # If no time limit, start the next round immediately but return the snapshot
+        start_next_round(game)
+        return end_of_round_state
+
+def unset_human_readiness(players):
+    """
+    Sets the 'ready' status of all human players in a list to False.
+    """
+    for player in players:
+        if not player.get("ai_agent"):
+            player["ready"] = False
+    return players
+
+def is_game_about_to_finish(game_state):
+    """
+    Predicts if the game will end after this round.
+    """
+    action_ids = get_action_ids(game_state.get("rules", {}))
+    losing_player_nickname = None
+    for event in reversed(game_state.get("history", [])):
+        if event.get("action_id") == action_ids["lose_round"]:
+            losing_player_nickname = event.get("player")
+            break
+
+    if not losing_player_nickname:
+        return False
+
+    temp_players = copy.deepcopy(game_state["players"])
+    losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
+
+    if not losing_player:
+        return False
+
+    losing_player["n_cards"] += 1
+    if losing_player["n_cards"] > game_state["max_cards"]:
+        losing_player["n_cards"] = 0
+
+    active_players = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
+    return active_players <= 1

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -313,15 +313,9 @@ def end_round(game, losing_player_nickname):
 
     # 2. Prepare the next live state
     # Use a temporary copy to determine the outcome without changing the state prematurely.
-    temp_players = copy.deepcopy(game["players"])
-    losing_player_obj = get_player_by_nickname(temp_players, losing_player_nickname)
-    if losing_player_obj:
-        losing_player_obj["n_cards"] += 1
-        if losing_player_obj["n_cards"] > game["max_cards"]:
-            losing_player_obj["n_cards"] = 0
-    active_players_count = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
+    temp_players = update_n_cards(game, losing_player_nickname)
     
-    if active_players_count <= 1:
+    if sum(1 for p in temp_players if p.get("n_cards", 0) > 0) <= 1:
         # Game is finished
         game["status"] = "Finished"
         game["players"] = temp_players # Use the updated player list
@@ -350,9 +344,19 @@ def unset_human_readiness(players):
             player["ready"] = False
     return players
 
-def is_game_about_to_finish(game_state):
+
+def update_n_cards(game, losing_player_nickname):
+    temp_players = copy.deepcopy(game["players"])
+    losing_player_obj = get_player_by_nickname(temp_players, losing_player_nickname)
+    losing_player_obj["n_cards"] += 1
+    if losing_player_obj["n_cards"] > game["max_cards"]:
+        losing_player_obj["n_cards"] = 0
+    return temp_players
+
+
+def was_this_the_last_round(game_state):
     """
-    Predicts if the game will end after this round.
+    Detects if this is a finished round after which there will be no more rounds.
     """
     action_ids = get_action_ids(game_state.get("rules", {}))
     losing_player_nickname = None
@@ -364,15 +368,5 @@ def is_game_about_to_finish(game_state):
     if not losing_player_nickname:
         return False
 
-    temp_players = copy.deepcopy(game_state["players"])
-    losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
-
-    if not losing_player:
-        return False
-
-    losing_player["n_cards"] += 1
-    if losing_player["n_cards"] > game_state["max_cards"]:
-        losing_player["n_cards"] = 0
-
-    active_players = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
-    return active_players <= 1
+    updated_players = update_n_cards(game_state, losing_player_nickname)
+    return sum(1 for p in updated_players if p.get("n_cards", 0) > 0) <= 1

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -154,30 +154,63 @@ def start_player_timer(game):
             return decimal.Decimal(str(time.time() + time_limit))
     return None
 
-def calculate_max_cards(n_players, rules):
-    deck_size = int(rules.get("deck_size", 24))
-    common_cards_rule = int(rules.get("common_cards", 0))
-    n_jokers = int(rules.get("jokers", 0))
 
-    # Max cards calculation: maximum cards that can be dealt accounting for the common cards rule and number of players
-    # For nicer gameplay, jokers decrease max cards acting as if the deck was smaller, by 4 cards for the first joker and 2 for each next joker
+def calculate_suggested_cards_in_round(rules):
+    """
+    Calculates the suggested total number of cards to be in play for optimal experience.
+    Computes the expanded deck size and applies a downward adjustment for jokers. 
+    Always caps the final result at base deck size to not prolong the game
+    """
+    base_deck_size = int(rules.get("deck_size", 24))
+    jokers = int(rules.get("jokers", 0))
+    blanks = int(rules.get("blanks", 0))
+    if jokers > 0:
+        suggested_total = (base_deck_size + blanks + jokers) / (1 + 0.2 * (jokers + 1))
+        return min(floor(suggested_total), base_deck_size)
+    else:
+        return base_deck_size
+        
+
+def calculate_max_cards_per_player(n_players, total_cards_in_play, common_cards_rule):
+    """Calculates the theoretical maximum number of cards a single player can hold."""
     # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
     # x*n*(1+rate) < deck_size + n*rate  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
-    pretend_deck_size = deck_size
-    if n_jokers > 0:
-        pretend_deck_size -= (2 + 2 * n_jokers)
+
     if common_cards_rule in (-1, -2):
         rate = get_common_cards_rate_by_id(common_cards_rule)
-        max_cards = int((pretend_deck_size + n_players * rate) / (n_players * (1 + rate)) - 0.001)
+        # Formula rearranged to solve for x (max_cards): x <= (total_cards - 1 + n*rate) / (n * (1 + rate))
+        max_cards = (total_cards_in_play + n_players * rate) / (n_players * (1 + rate)) - 0.001
+        return min(floor(max_cards), 11)
     else:
-        max_cards = int((pretend_deck_size - common_cards_rule) / n_players)
-    return max_cards if max_cards <= 11 else 11
+        max_cards = (total_cards_in_play - common_cards_rule) / n_players
+        return min(floor(max_cards), 11)
 
 def start_game(game):
     game_uuid = game["game_uuid"]
     players = game["players"]
     rules = game.get("rules", {})
-    max_cards = calculate_max_cards(len(players), rules)
+    n_players = len(players)
+
+    # Determine the final max_cards value
+    custom_max_cards = int(game.get("max_cards", 0))
+    deck_size = int(rules.get("deck_size", 24))
+    jokers = int(rules.get("jokers", 0))
+    blanks = int(rules.get("blanks", 0))
+    common_cards_rule = int(rules.get("common_cards", 0))
+
+    if custom_max_cards == 0: # Auto-calculate
+        suggested_total = calculate_suggested_cards_in_round(rules)
+        max_cards = calculate_max_cards_per_player(n_players, suggested_total, common_cards_rule)
+    else: # Validate and use custom value
+        theoretical_max = calculate_max_cards_per_player(n_players, deck_size + jokers + blanks, common_cards_rule)
+        if custom_max_cards > theoretical_max:
+            return {
+                "success": False,
+                "error": "MAX_CARDS_TOO_HIGH",
+                "message": f"With {n_players} players, max cards cannot exceed {theoretical_max}. Please adjust rules."
+            }
+        else:
+            max_cards = custom_max_cards
 
     for player in players:
         player["n_cards"] = 1
@@ -214,7 +247,7 @@ def start_game(game):
             '#game_status': "status"
         }
     )
-    return True
+    return {"success": True}
 
 def start_next_round(game):
     """

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -4,7 +4,7 @@ from math import floor
 import time
 import decimal
 import copy
-from .db import table, save_in_dynamodb
+from .db import table, save_in_dynamodb, transact_end_of_round
 from .time_limit import send_time_limit_message
 from .logging import logger
 
@@ -298,42 +298,56 @@ def get_action_ids(rules):
 
 def end_round(game, losing_player_nickname):
     """
-    Handles all the logic for ending a round. If a time limit is active,
-    it puts the game into a "Waiting for ready" state instead of starting the next round.
+    Atomically handles the end of a round using a DynamoDB transaction.
+    Returns the archived game state on success, or False if the transaction fails.
     """
+    original_last_modified = game.get("last_modified")
     action_ids = get_action_ids(game.get("rules", {}))
-    game["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
-    game["cp_nickname"] = None
-    game["move_deadline"] = None
-    end_of_round_state = copy.deepcopy(game)
-    save_in_dynamodb(end_of_round_state, f"{end_of_round_state['game_uuid']}_{int(end_of_round_state['round_number'])}")
-
-    # Check for game end condition *before* altering the live state
-    temp_players = copy.deepcopy(game["players"])
-    temp_losing_player = get_player_by_nickname(temp_players, losing_player_nickname)
-    temp_losing_player["n_cards"] += 1
-    if temp_losing_player["n_cards"] > game["max_cards"]:
-        temp_losing_player["n_cards"] = 0
-    
-    active_players = sum(1 for p in temp_players if p["n_cards"] > 0)
-    if active_players <= 1:
-        game["status"] = "Finished"
-        game["players"] = temp_players
-        save_in_dynamodb(game)
-        return end_of_round_state
-
-    # If game is not over, decide the next step
-    active_human_players = [p for p in temp_players if p.get("n_cards") > 0 and not p.get("ai_agent")]
     time_limit = int(game.get("rules", {}).get("time_limit", 0))
-    if time_limit > 0 and active_human_players:
-        game["status"] = "Waiting for ready"
-        game["players"] = unset_human_readiness(game["players"])
-        save_in_dynamodb(game)
-        return game # For timed games, return the waiting state
+
+    # 1. Prepare the archive state
+    archive_state = copy.deepcopy(game)
+    archive_state["game_uuid"] = f"{game['game_uuid']}_{game['round_number']}"
+    archive_state["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
+    archive_state["cp_nickname"] = None
+    archive_state["move_deadline"] = None
+
+    # 2. Prepare the next live state
+    # Use a temporary copy to determine the outcome without changing the state prematurely.
+    temp_players = copy.deepcopy(game["players"])
+    losing_player_obj = get_player_by_nickname(temp_players, losing_player_nickname)
+    if losing_player_obj:
+        losing_player_obj["n_cards"] += 1
+        if losing_player_obj["n_cards"] > game["max_cards"]:
+            losing_player_obj["n_cards"] = 0
+    active_players_count = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
+    
+    if active_players_count <= 1:
+        # Game is finished
+        next_live_state = copy.deepcopy(game)
+        next_live_state["status"] = "Finished"
+        next_live_state["players"] = temp_players # Use the updated player list
+        next_live_state["history"] = []
+        next_live_state["cp_nickname"] = None
+        next_live_state["move_deadline"] = None
+        if transact_end_of_round(next_live_state, archive_state, original_last_modified):
+            return archive_state
+    elif time_limit > 0 and any(p for p in game["players"] if p.get("n_cards") > 0 and not p.get("ai_agent")):
+        # Game is timed and will wait for players
+        next_live_state = copy.deepcopy(archive_state) # Start from the archive state
+        next_live_state["game_uuid"] = game["game_uuid"] # Reset the UUID to the live one
+        next_live_state["status"] = "Waiting for ready"
+        next_live_state["players"] = unset_human_readiness(next_live_state["players"])
+        if transact_end_of_round(next_live_state, archive_state, original_last_modified):
+            return archive_state
     else:
-        # If no time limit, start the next round immediately but return the snapshot
+        # No finish and no time limit: save archive state unconditionally and start the next round
+        save_in_dynamodb(archive_state)
+        game["history"] = archive_state["history"]
         start_next_round(game)
-        return end_of_round_state
+        return archive_state
+
+    return False # This is only reached if a transaction fails
 
 def unset_human_readiness(players):
     """

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -305,12 +305,13 @@ def end_round(game, losing_player_nickname):
     action_ids = get_action_ids(game.get("rules", {}))
     time_limit = int(game.get("rules", {}).get("time_limit", 0))
 
+    game["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
+    game["cp_nickname"] = None
+    game["move_deadline"] = None
+
     # 1. Prepare the archive state
     archive_state = copy.deepcopy(game)
     archive_state["game_uuid"] = f"{game['game_uuid']}_{game['round_number']}"
-    archive_state["history"].append({"player": losing_player_nickname, "action_id": action_ids["lose_round"]})
-    archive_state["cp_nickname"] = None
-    archive_state["move_deadline"] = None
 
     # 2. Prepare the next live state
     # Use a temporary copy to determine the outcome without changing the state prematurely.
@@ -324,26 +325,19 @@ def end_round(game, losing_player_nickname):
     
     if active_players_count <= 1:
         # Game is finished
-        next_live_state = copy.deepcopy(game)
-        next_live_state["status"] = "Finished"
-        next_live_state["players"] = temp_players # Use the updated player list
-        next_live_state["history"] = []
-        next_live_state["cp_nickname"] = None
-        next_live_state["move_deadline"] = None
-        if transact_end_of_round(next_live_state, archive_state, original_last_modified):
+        game["status"] = "Finished"
+        game["players"] = temp_players # Use the updated player list
+        if transact_end_of_round(game, archive_state, original_last_modified):
             return archive_state
     elif time_limit > 0 and any(p for p in game["players"] if p.get("n_cards") > 0 and not p.get("ai_agent")):
-        # Game is timed and will wait for players
-        next_live_state = copy.deepcopy(archive_state) # Start from the archive state
-        next_live_state["game_uuid"] = game["game_uuid"] # Reset the UUID to the live one
-        next_live_state["status"] = "Waiting for ready"
-        next_live_state["players"] = unset_human_readiness(next_live_state["players"])
-        if transact_end_of_round(next_live_state, archive_state, original_last_modified):
-            return archive_state
+        # Game is timed and waiting for human players' readiness
+        game["status"] = "Waiting for ready"
+        game["players"] = unset_human_readiness(game["players"])
+        if transact_end_of_round(game, archive_state, original_last_modified):
+            return game
     else:
         # No finish and no time limit: save archive state unconditionally and start the next round
         save_in_dynamodb(archive_state)
-        game["history"] = archive_state["history"]
         start_next_round(game)
         return archive_state
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -32,7 +32,9 @@ def find_next_active_player(players, cp_nickname):
 
 def get_revealed_hands(game, current_round, current_status, player_authenticated, player_nickname):
     revealed_hands = []
-    if game["round_number"] < current_round or current_status in ["Finished", "Waiting for ready"]:
+    if current_status == "Finished":
+        revealed_hands = game["hands"]
+    elif game["round_number"] < current_round or current_status == "Waiting for ready":
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"])]
     elif player_authenticated and game["round_number"] == current_round:
         revealed_hands = [hand for hand in game["hands"] if is_active_player(game["players"], hand["nickname"]) and hand["nickname"] == player_nickname]

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -61,12 +61,19 @@ def censor_game(game, current_round, player_authenticated, player_nickname):
         "rules": game.get("rules", {})
     }
 
+def get_common_cards_rate_by_id(rule):
+    if rule == -2:
+        return 1/5
+    if rule == -1:
+        return 1/3
+    return False
+
 def calculate_common_cards(players, rules):
     common_cards_rule = int(rules.get("common_cards", 0))
     if common_cards_rule in (-1, -2):
-        player_hand_sizes = [int(p.get("n_cards")) for p in players]
-        smallest_hand_size = min(n for n in player_hand_sizes if n>0)
-        return int((smallest_hand_size+1)/2) if common_cards_rule == -2 else smallest_hand_size
+        extra_cards_per_hand = [hs-1 for hs in [int(p.get("n_cards")) for p in players] if hs>0]
+        rate = get_common_cards_rate_by_id(common_cards_rule)
+        return int(1 + sum(extra_cards_per_hand) * rate)
     else:
         return common_cards_rule
 
@@ -148,17 +155,20 @@ def start_game(game):
     players = game["players"]
     rules = game.get("rules", {})
     n_players = len(players)
-    deck_size = rules.get("deck_size", 24)
+    deck_size = int(rules.get("deck_size", 24))
     common_cards_rule = int(rules.get("common_cards", 0))
 
     for player in players:
         player["n_cards"] = 1
 
-    num_common_cards = calculate_common_cards(players, rules)
-
-    numerator = deck_size - num_common_cards if common_cards_rule > 0 else deck_size
-    denominator = n_players + 1 if common_cards_rule in (-1, -2) else n_players
-    max_cards = floor(numerator / denominator)
+    # Max cards calculation: maximum cards that can be dealt accounting for the common cards rule but excluding jokers and blanks
+    # x*n + 1 + floor((x-1)*n*rate) <= deck_size  ->  x*n + 1 + (x-1)*n*rate < deck_size + 1  ->   x*n + x*n*rate - n*rate < deck_size  ->
+    # x*n*(1+rate) < deck_size + (n*rate)  ->  x < (deck_size + n*rate) / (n * (1+rate))  ->  x = int((deck_size + n*rate) / (n * (1+rate)) - epsilon)
+    if common_cards_rule in (-1, -2):
+        rate = get_common_cards_rate_by_id(common_cards_rule)
+        max_cards = int((deck_size + n_players * rate) / (n_players * (1 + rate)) - 0.001)
+    else:
+        max_cards = int((deck_size - common_cards_rule) / n_players)
     if max_cards > 11: max_cards = 11
 
     public = "false"

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -312,3 +312,26 @@ def is_game_about_to_finish(game_state):
 
     active_players = sum(1 for p in temp_players if p.get("n_cards", 0) > 0)
     return active_players <= 1
+
+def are_rules_unsupported_by_ai(rules):
+    """
+    Hopefully temporary O_O.
+    """
+    return (
+        int(rules.get("deck_size", 24)) != 24 or
+        int(rules.get("common_cards", 0)) != 0 or
+        int(rules.get("jokers", 0)) != 0 or
+        int(rules.get("blanks", 0)) != 0 or
+        not rules.get("standard_order", True)
+    )
+
+def update_ai_readiness(players, rules):
+    """
+    Updates the readiness of AI players based on the complexity of game rules.
+    Human player readiness is unaffected.
+    """
+    rules_are_unsupported = are_rules_unsupported_by_ai(rules)
+    for player in players:
+        if player.get("ai_agent"):
+            player["ready"] = not rules_are_unsupported
+    return players

--- a/api/shared/time_limit.py
+++ b/api/shared/time_limit.py
@@ -1,0 +1,42 @@
+import os
+import boto3
+import json
+from botocore.exceptions import ClientError
+from .response import DecimalEncoder
+
+sqs_client = boto3.client("sqs")
+TIME_LIMIT_QUEUE_NAME = os.environ.get("time_limit_queue_name")
+
+def get_time_limit_queue_url():
+    """
+    Returns the URL of the time limit SQS queue.
+    """
+    try:
+        return sqs_client.get_queue_url(QueueName=TIME_LIMIT_QUEUE_NAME)['QueueUrl']
+    except ClientError:
+        return None
+
+def send_time_limit_message(game_uuid, player_uuid, round_number, time_limit, history_len):
+    """
+    Sends a delayed message to the SQS queue to trigger a timeout check.
+    """
+    queue_url = get_time_limit_queue_url()
+    if not queue_url:
+        print("Warning: Time limit queue URL not found.")
+        return
+
+    try:
+        payload = {
+            "game_uuid": game_uuid,
+            "player_uuid": player_uuid,
+            "round_number": round_number,
+            "history_len": history_len
+        }
+        sqs_client.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps(payload, cls=DecimalEncoder),
+            DelaySeconds=time_limit
+        )
+    except ClientError as e:
+        print(f"Error sending SQS message: {e}")
+        pass

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -1,6 +1,7 @@
 from shared.response import *
 from shared.db import get_from_dynamodb
 from shared.api_gateway import parse_event
+from shared.constants import GameStatus, RuleValues
 from shared.inputs import is_valid_uuid
 from shared.game import start_game
 
@@ -18,7 +19,7 @@ def lambda_handler(event, context):
         if not game:
             return parameter_error_payload("game_uuid", game_uuid, message="Game does not exist")
 
-        if game.get("status") != "Not started":
+        if game.get("status") != GameStatus.NOT_STARTED:
             return error_payload(403, "Game already started")
 
         admin_uuid = str(body.get("admin_uuid"))
@@ -38,7 +39,7 @@ def lambda_handler(event, context):
         if n_players < 2:
             return error_payload(403, "At least 2 players needed to start a game")
 
-        if  int(game.get("rules", {}).get("time_limit", 0)) > 0:
+        if  int(game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_DEFAULT)) > RuleValues.TIME_LIMIT_NO_LIMIT:
             return error_payload(403, "Games with a time limit can only start when everyone is ready")
 
         start_game(game)

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -38,6 +38,9 @@ def lambda_handler(event, context):
         if n_players < 2:
             return error_payload(403, "At least 2 players needed to start a game")
 
+        if  int(game.get("rules", {}).get("time_limit", 0)) > 0:
+            return error_payload(403, "Games with a time limit can only start when everyone is ready")
+
         start_result = start_game(game)
         if not start_result.get("success"):
             return error_payload(403, start_result.get("message"))

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -1,64 +1,8 @@
-import time
-from math import floor
-from random import shuffle, choice
-import decimal
-from shared.response import * 
-from shared.db import table, get_from_dynamodb
+from shared.response import *
+from shared.db import get_from_dynamodb
 from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
-from shared.game import draw_cards
-
-
-def arrange_players(players):
-    """
-        Order the human and AI players
-        for optimal gameplay
-    """
-    num_total = len(players)
-    num_ais = sum(1 for p in players if p.get("ai_agent"))
-    offset = choice(range(num_total))
-
-    ai_positions_from_zero = [floor(i * num_total / num_ais) for i in range(num_ais)]
-    ai_positions = [(i + offset) % num_total for i in ai_positions_from_zero]
-    ai_players = [p for p in players if p.get("ai_agent")]
-
-    human_players = [p for p in players if not p.get("ai_agent")]
-    shuffle(human_players)
-
-    players = []
-
-    for i in range(num_total):
-        if i in ai_positions and ai_players:
-            players.append(ai_players.pop(0))
-        elif human_players:
-            players.append(human_players.pop(0))
-
-    return players
-
-
-def update_in_dynamodb(game_uuid, public, status, round_number, max_cards, players, hands, cp_nickname):
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, max_cards = :max_cards, hands = :hands, cp_nickname = :cp_nickname",
-        ExpressionAttributeValues={
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':players': players,
-            ':public': public,
-            ':status': status,
-            ':round_number': round_number,
-            ':max_cards': max_cards,
-            ':hands': hands,
-            ':cp_nickname': cp_nickname
-        },
-        ExpressionAttributeNames={
-            '#game_public': "public",
-            '#game_status': "status"
-        },
-        ReturnValues="NONE"
-    )
-    return True
+from shared.game import start_game
 
 
 def lambda_handler(event, context):
@@ -95,22 +39,7 @@ def lambda_handler(event, context):
         if n_players < 2:
             return error_payload(403, "At least 2 players needed to start a game")
 
-        public = "false"
-        status = "Running"
-        round_number = 1
-        max_cards = 11
-        if n_players > 2:
-            max_cards = floor(24 / n_players)
-
-        for player in players:
-            player["n_cards"] = 1
-        players = arrange_players(players)
-
-        hands = draw_cards(players)
-
-        cp_nickname = players[0]["nickname"]
-
-        update_in_dynamodb(game_uuid, public, status, round_number, max_cards, players, hands, cp_nickname)
+        start_game(game)
 
         return response_payload(202, {"message": "Game started"})
 

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -41,9 +41,7 @@ def lambda_handler(event, context):
         if  int(game.get("rules", {}).get("time_limit", 0)) > 0:
             return error_payload(403, "Games with a time limit can only start when everyone is ready")
 
-        start_result = start_game(game)
-        if not start_result.get("success"):
-            return error_payload(403, start_result.get("message"))
+        start_game(game)
 
         return response_payload(202, {"message": "Game started"})
 

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -4,7 +4,6 @@ from shared.api_gateway import parse_event
 from shared.inputs import is_valid_uuid
 from shared.game import start_game
 
-
 def lambda_handler(event, context):
     try:
         body = parse_event(event)
@@ -39,7 +38,9 @@ def lambda_handler(event, context):
         if n_players < 2:
             return error_payload(403, "At least 2 players needed to start a game")
 
-        start_game(game)
+        start_result = start_game(game)
+        if not start_result.get("success"):
+            return error_payload(403, start_result.get("message"))
 
         return response_payload(202, {"message": "Game started"})
 

--- a/api/timeout_player.py
+++ b/api/timeout_player.py
@@ -1,0 +1,30 @@
+import json
+from shared.response import *
+from shared.db import get_from_dynamodb
+from shared.game import get_nickname_by_uuid, end_round
+
+def lambda_handler(event, context):
+    try:
+        for record in event['Records']:
+            body = json.loads(record['body'])
+            game_uuid = body.get("game_uuid")
+            player_uuid = body.get("player_uuid")
+            round_number = body.get("round_number")
+            history_len_at_send = body.get("history_len")
+
+            game = get_from_dynamodb(game_uuid)
+            
+            # Ignore if game is not in the correct state
+            if not game or game.get("status") != "Running" or game.get("round_number") != round_number:
+                continue
+            
+            player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
+            
+            current_history_len = len(game.get("history", []))
+            if game.get("cp_nickname") == player_nickname and current_history_len == history_len_at_send:
+                end_round(game, player_nickname)
+
+        return response_payload(200, {"message": "Timeouts processed"})
+
+    except Exception as err:
+        return internal_error_payload(err)

--- a/api/timeout_player.py
+++ b/api/timeout_player.py
@@ -1,5 +1,6 @@
 import json
 from shared.response import *
+from shared.constants import GameStatus
 from shared.db import get_from_dynamodb
 from shared.game import get_nickname_by_uuid, end_round
 
@@ -15,7 +16,7 @@ def lambda_handler(event, context):
             game = get_from_dynamodb(game_uuid)
             
             # Ignore if game is not in the correct state
-            if not game or game.get("status") != "Running" or game.get("round_number") != round_number:
+            if not game or game.get("status") != GameStatus.RUNNING or game.get("round_number") != round_number:
                 continue
             
             player_nickname = get_nickname_by_uuid(game["players"], player_uuid)

--- a/api/watch-game-connect.py
+++ b/api/watch-game-connect.py
@@ -35,8 +35,7 @@ def register_game_watcher(game_uuid, player_uuid, reactions_enabled, connection_
         if not is_valid_uuid(player_uuid):
             return parameter_error_payload("player_uuid", player_uuid, message="Invalid player UUID")
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-        player_authenticated = bool(player_nickname)
-        if not player_authenticated:
+        if not player_nickname:
             return parameter_error_payload("player_uuid", player_uuid, message="The UUID does not match any active player")
 
     connection_object = {

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -108,11 +108,7 @@ def update_game_watchers(game):
     logger.info(connected_players)
     for connection_id, player_uuid in connected_players:
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-        action_ids = get_action_ids(game.get("rules", {}))
-        is_end_of_round = any(str(val.get("action_id")) == str(action_ids["lose_round"]) for val in game.get("history", []))
-        current_round = game["round_number"] + 1 if is_end_of_round else game["round_number"]
-        visible_game = censor_game(game, current_round, player_nickname)
-        post_to_connection(visible_game, connection_id)
+        post_to_connection(censor_game(game, player_nickname), connection_id)
 
 
 def update_public_games_watchers(game, game_old):

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -108,11 +108,10 @@ def update_game_watchers(game):
     logger.info(connected_players)
     for connection_id, player_uuid in connected_players:
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-        player_authenticated = bool(player_nickname)
         action_ids = get_action_ids(game.get("rules", {}))
         is_end_of_round = any(str(val.get("action_id")) == str(action_ids["lose_round"]) for val in game.get("history", []))
         current_round = game["round_number"] + 1 if is_end_of_round else game["round_number"]
-        visible_game = censor_game(game, current_round, player_authenticated, player_nickname)
+        visible_game = censor_game(game, current_round, player_nickname)
         post_to_connection(visible_game, connection_id)
 
 

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 import json
 from shared.response import * 
 from shared.api_gateway import parse_event
-from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, was_this_the_last_round
+from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, is_update_redundant
 from shared.logging import logger
 from shared.db import websocket_table
 
@@ -167,10 +167,8 @@ def lambda_handler(event, context):
             new_game_state = game.get("new", {})
             if not new_game_state:
                 continue
-            is_snapshot = "_" in new_game_state.get("game_uuid", "")
-            is_timed_game = new_game_state.get("rules", {}).get("time_limit", 0) > 0
-            if is_snapshot and is_timed_game and not was_this_the_last_round(new_game_state):
-                logger.info('## SKIPPING END OF ROUND SNAPSHOT BROADCAST FOR TIMED GAME THAT HAS NOT FINISHED')
+            if is_update_redundant(new_game_state):
+                logger.info('## SKIPPING REDUNDANT UPDATE')
                 continue
 
             logger.info('## UPDATING WATCHERS')

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 import json
 from shared.response import * 
 from shared.api_gateway import parse_event
-from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, get_action_ids, is_game_about_to_finish
+from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, was_this_the_last_round
 from shared.logging import logger
 from shared.db import websocket_table
 
@@ -169,10 +169,9 @@ def lambda_handler(event, context):
                 continue
             is_snapshot = "_" in new_game_state.get("game_uuid", "")
             is_timed_game = new_game_state.get("rules", {}).get("time_limit", 0) > 0
-            if is_snapshot and is_timed_game:
-                if not is_game_about_to_finish(new_game_state):
-                    logger.info('## SKIPPING EOR SNAPSHOT BROADCAST FOR TIMED GAME (NOT FINISHING)')
-                    continue
+            if is_snapshot and is_timed_game and not was_this_the_last_round(new_game_state):
+                logger.info('## SKIPPING END OF ROUND SNAPSHOT BROADCAST FOR TIMED GAME THAT HAS NOT FINISHED')
+                continue
 
             logger.info('## UPDATING WATCHERS')
             update_watchers(game)

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 import json
 from shared.response import * 
 from shared.api_gateway import parse_event
-from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game
+from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, get_action_ids, is_game_about_to_finish
 from shared.logging import logger
 from shared.db import websocket_table
 
@@ -109,7 +109,9 @@ def update_game_watchers(game):
     for connection_id, player_uuid in connected_players:
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
         player_authenticated = bool(player_nickname)
-        current_round = game["round_number"] + 1 if any(str(val["action_id"])=="89" for val in game.get("history")) else game["round_number"]
+        action_ids = get_action_ids(game.get("rules", {}))
+        is_end_of_round = any(str(val.get("action_id")) == str(action_ids["lose_round"]) for val in game.get("history", []))
+        current_round = game["round_number"] + 1 if is_end_of_round else game["round_number"]
         visible_game = censor_game(game, current_round, player_authenticated, player_nickname)
         post_to_connection(visible_game, connection_id)
 
@@ -164,6 +166,19 @@ def lambda_handler(event, context):
         for game in games:
             logger.info('## GAME')
             logger.info(game)
+
+            # If it's a timed game, it's the EOR state and the game isn't about to finish, skip update
+            # That's because this state will cause a flicker at best (fraction of a second before the 'waiting state') or glitching UI at worst
+            new_game_state = game.get("new", {})
+            if not new_game_state:
+                continue
+            is_snapshot = "_" in new_game_state.get("game_uuid", "")
+            is_timed_game = new_game_state.get("rules", {}).get("time_limit", 0) > 0
+            if is_snapshot and is_timed_game:
+                if not is_game_about_to_finish(new_game_state):
+                    logger.info('## SKIPPING EOR SNAPSHOT BROADCAST FOR TIMED GAME (NOT FINISHING)')
+                    continue
+
             logger.info('## UPDATING WATCHERS')
             update_watchers(game)
             logger.info('## QUEUEING AI IF NEEDED')


### PR DESCRIPTION
Readiness mechanic:
* Each player gets a 'ready' property upon creation (always True for AIs; initially False for humans)
* There's a `set_readiness` endpoint, where everybody can set themselves ready or not ready
* When all players are ready and there are at least 2, start game
* A sole player cannot get ready

Alternative rules:
* On creation, the game object gets a rules property, listing all rules with their values. The default are the old rules
* There is a `change_rules` endpoint
  * The admin has to authenticate themselves
  * As many parameters as rules, including the preference for max cards
  * Every change of rules after which there's (still) a time limit removes every human player's readiness
* Rule: time limit
  * Specified in integer seconds. Default is no limit (represented as 0)
  * If there is a limit, the play endpoint or the readiness endpoint puts an item in an SQS queue that triggers a lambda with delay. That lambda checks if the move was made. If not, it makes the player lose. Then, going to a new round requires everybody getting ready again
  * Engine outputs `move_deadline` and `update_time` with the game state, in addition to `last_modified`, giving clients a few ways to calculate/model how much time the user really has for their move 
* Rule: deck size
  * 24 (default) or 32
  * Card values are 0-5 (like now) or 0-7
  * `determine_set_existence` now calls specialised functions, like `check_four_of_a_kind` instead of storing full indexations
* Rule: common cards:
  * Integer number, applicable to all rounds. Default 0. In practice clients would present a few options
  * They are extra cards visible to everybody
  * The common hand is a new game state property
  * Alternatively, players can turn on an increasing number of common cards, represented as -1 or -2 in the rules
* Rule: add jokers and blanks to the deck
  * Integer number for both. Default 0 and 0
  * Jokers count towards every set, blanks count towards none. However, when you're checked, only your and common jokers count
  * Represented as value -1 and suit -1 (jokers) and value -2 and suit -2 (blanks)

> * Additional rule abandoned partway through the PR: standard order (bool, default True)
>   * If False, you guess which set is not there. You need to go down in seniority

The maximum number of cards:
* Can be changed by players using the change-rules endpoint
* The admin's preference is saved as a property in the rules object
* If the request is for too many cards, the maximum possible are set so that the game start isn't blocked by this
* If there's no preference, an automatic suggestion is used instead
* The suggestion is now more complex and is a function of the rules and number of players
* In any case, 11 cards per player is a hard limit
* The final max cards value that's going to be used if players start the game right now is now displayed in the (already existent) `max_cards` property of the game state. It's 0 when there is only 1 player

There is now an endpoint allowing the admin to remove all AIs.

The PR includes some improvements to related code, such as refactoring of game statuses into named constants.

The README has been largely rewritten. The top-level README is now more concise, while the API README contains more detail.

As of [4794fcc](https://github.com/Blef-team/blef_game_engine/pull/211/commits/4794fcc6010e2d247d776a25a927dc51b357e024), it leaves open the possibility of starting a non-timed game through readiness - this is still up for discussion/experimentation