### PR TITLE
Wire API-Gateway Lambdas to SnapStart versions via a prod alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ In order to interact with the engine using a custom app or a basic HTTP interfac
 This service is built with a serverless architecture on AWS and includes:
 
 * **API:** AWS API Gateway (HTTP & WebSocket)
-* **Compute:** AWS Lambda functions in Python
+* **Compute:** AWS Lambda functions in Python. The API-Gateway-fronted handlers run with [SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) and are invoked via a `prod` alias pointing at a published version (see the [deployment readme](deployment/README.md#api-gateway-is-wired-to-lambda-via-the-prod-alias-of-a-published-snapstart-version))
 * **Database:** AWS DynamoDB
 * **Messaging:** AWS SQS
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,6 +8,64 @@ Game states are currently stored in and retrieved from AWS DynamoDB. Game state 
 
 AI Agents are implemented with Lambda functions. Scheduling their actions is done using an AWS SQS queue.
 
+### API Gateway is wired to Lambda via the `prod` alias of a published, SnapStart version
+
+> **Important for anyone deploying or editing these functions.**
+
+The Lambda functions that sit directly behind API Gateway are **not** invoked on their
+`$LATEST` (unpublished) code. To reduce cold starts, each of these functions has
+[Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) enabled
+(`SnapStart.ApplyOn = PublishedVersions`). SnapStart only applies to **published, numbered
+versions** — never `$LATEST` — so for each function we:
+
+1. Enable SnapStart on the function.
+2. **Publish a version**, which builds the SnapStart snapshot for that immutable code.
+3. Point a **`prod` alias** at that version.
+4. Configure the **API Gateway integration to invoke the `prod` alias ARN**
+   (e.g. `…:function:blef-get-game:prod`), not the bare function ARN.
+
+Because API Gateway targets the stable `prod` alias, deploys never need to re-touch the
+integration: publishing a new version and moving the alias is enough, and API Gateway
+serves the new SnapStart-optimized version automatically.
+
+**Functions wired this way** (API Gateway integration → `:prod` alias → published version):
+
+| API | Functions |
+|-----|-----------|
+| HTTP API (`blef-game-engine-http-api`) | `blef-create-game`, `blef-get-game`, `blef-join-game`, `blef-play`, `blef-start-game`, `blef-set-readiness`, `blef-change-rules`, `blef-change-team`, `blef-make-public`, `blef-make-private`, `blef-remove-player`, `blef-remove-ais`, `blef-send-reaction`, `blef-list-public-games`, `blef-invite-aiagent` |
+| WebSocket API (`blef-watch-game-websocket-api`) | `blef-watch-game-connect`, `blef-watch-game-disconnect` |
+
+All other Lambdas (DynamoDB-stream, SQS, and cron-triggered handlers such as
+`blef-watch-game-stream`, `blef-aiagent-*`, `blef-clean-public-games`,
+`blef-timeout-player`) are invoked on `$LATEST` and are **not** alias-managed.
+
+#### What `deploy.sh` does for these functions
+
+`deploy.sh` keeps a list of the alias-managed function names (`ALIAS_MANAGED`). For those,
+after `update-function-code` it additionally:
+
+- waits for the code update to settle,
+- **publishes a new version** (a fresh SnapStart snapshot is built — this can take a
+  minute or two while the version is in `Pending`),
+- waits for that version to become `Active`,
+- **moves the `prod` alias** to the new version.
+
+Functions not in `ALIAS_MANAGED` continue to deploy straight to `$LATEST` as before.
+
+#### Rolling back
+
+Because every deploy leaves the previous numbered version intact, a rollback is just
+re-pointing the alias — no code redeploy required:
+
+```bash
+aws lambda update-alias --function-name blef-get-game --name prod --function-version <previous_version>
+```
+
+> Note: the HTTP API stage (`$default`) has auto-deploy enabled, so integration changes
+> take effect immediately. The WebSocket API stage (`production`) does **not** auto-deploy
+> — if you ever change a WebSocket integration or route, run
+> `aws apigatewayv2 create-deployment --api-id <ws-api-id> --stage-name production`.
+
 
 ### Architecture overview
 ![Blef architecture](https://user-images.githubusercontent.com/10632991/146104548-3e4693ab-4889-43c2-b7a0-e4d47d52fb36.png)

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -9,6 +9,19 @@ SHARED_DIR="shared"
 # Temporary directory for staging zip contents
 TEMP_DIR="deployment_temp"
 
+# Functions that are fronted by API Gateway via the "prod" alias of a published,
+# SnapStart-optimized version (see deployment/README.md). For these, updating the
+# code on $LATEST is NOT enough: API Gateway invokes the immutable "prod" alias, so
+# after pushing code we must publish a new version (which builds a fresh SnapStart
+# snapshot) and move the "prod" alias to it. Listed by full AWS function name.
+ALIAS_MANAGED=" \
+blef-create-game blef-get-game blef-join-game blef-play blef-start-game \
+blef-set-readiness blef-change-rules blef-change-team blef-make-public blef-make-private \
+blef-remove-player blef-remove-ais blef-send-reaction blef-list-public-games blef-invite-aiagent \
+blef-watch-game-connect blef-watch-game-disconnect "
+# The alias API Gateway integrations point at.
+PROD_ALIAS="prod"
+
 # Check if api directory exists
 if [ ! -d "$API_DIR" ]; then
   echo "Error: API directory '$API_DIR' not found. Run script from project root."
@@ -80,6 +93,26 @@ for f in "$API_DIR"/*.py; do
 
     if [ $? -eq 0 ]; then
         echo "✅ Successfully updated blef-$aws_function_name."
+
+        # If this function is wired to API Gateway via the "prod" alias, publish a
+        # new SnapStart-optimized version and move the alias to it. API Gateway
+        # invokes the alias, so it picks up the new version with no integration change.
+        if [[ "$ALIAS_MANAGED" == *" blef-$aws_function_name "* ]]; then
+            echo "  ↳ API-Gateway-fronted function: publishing new SnapStart version..."
+            aws lambda wait function-updated-v2 --function-name "blef-$aws_function_name"
+            new_version=$(aws lambda publish-version --function-name "blef-$aws_function_name" --query 'Version' --output text)
+            if [ -n "$new_version" ] && [ "$new_version" != "None" ]; then
+                echo "  ↳ Published version $new_version; waiting for SnapStart snapshot to become Active..."
+                aws lambda wait published-version-active --function-name "blef-$aws_function_name" --qualifier "$new_version"
+                if aws lambda update-alias --function-name "blef-$aws_function_name" --name "$PROD_ALIAS" --function-version "$new_version" > /dev/null; then
+                    echo "  ↳ ✅ '$PROD_ALIAS' alias now points to version $new_version (API Gateway uses it automatically)."
+                else
+                    echo "  ↳ ❌ Failed to move '$PROD_ALIAS' alias. New code is live on \$LATEST but NOT yet served by API Gateway."
+                fi
+            else
+                echo "  ↳ ❌ Failed to publish a new version; '$PROD_ALIAS' alias left unchanged."
+            fi
+        fi
     else
         echo "❌ Error: Failed to update blef-$aws_function_name."
         # Consider adding retry logic or specific error handling


### PR DESCRIPTION
## What & why

The Lambda handlers behind API Gateway (HTTP + WebSocket) ran on `$LATEST` with no cold-start mitigation (`python3.12`, 128 MB). Measured cold starts over 7 days added **~500 ms (up to ~800 ms)** of init to first requests — e.g. `get-game` had 353 cold starts averaging 506 ms init.

This enables **Lambda SnapStart** on those functions and fronts them with a published, snapshotted version through a stable **`prod` alias**. Post-change, the request path shows `Restore Duration` instead of `Init Duration` (down to ~73 ms on warm environments).

## How it's wired

API Gateway integration → **`prod` alias** → **published, SnapStart-snapshotted version** (never `$LATEST`). Because the integration targets the stable alias, deploys never re-touch the integration — publishing a new version and moving the alias is enough.

**Alias-managed functions (17):**
- HTTP API: `create-game, get-game, join-game, play, start-game, set-readiness, change-rules, change-team, make-public, make-private, remove-player, remove-ais, send-reaction, list-public-games, invite-aiagent`
- WebSocket API: `watch-game-connect, watch-game-disconnect`

All other Lambdas (DynamoDB-stream, SQS, cron handlers) still run on `$LATEST`.

## Changes in this PR (code/docs)

- **`deploy.sh`** — for alias-managed functions, after `update-function-code`: publish a new (SnapStart-snapshotted) version, wait for it to become `Active`, and move the `prod` alias. Other functions deploy to `$LATEST` unchanged.
- **`deployment/README.md`** — documents the wiring, the function list, deploy behaviour, rollback, and the WebSocket stage's lack of auto-deploy.
- **`README.md`** — notes SnapStart + prod-alias in the tech stack.

## Infra applied out-of-band (already live)

SnapStart enabled, versions published, `prod` aliases created, invoke permissions added for the alias ARNs, and the 15 HTTP + 2 WebSocket integrations re-pointed at `:prod`. Verified: `GET /games` returns 200 through the alias; logs show SnapStart `Restore Duration`.

## Notes / follow-ups
- Left the **dangling `blef-active-games` HTTP integration** untouched — it targets a function that doesn't exist (`ResourceNotFoundException`). Pre-existing; worth cleaning up separately.
- Restored the WebSocket `$default` route's missing MOCK target (it had been detached; blocked the stage deployment).
- Restore times still run ~580 ms on cold environments because restore is CPU-bound at 128 MB — a memory bump would reduce this further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)