### PR TITLE
Parallelise websocket broadcasts and cache SQS queue URLs

### DIFF
--- a/api/send-reaction.py
+++ b/api/send-reaction.py
@@ -14,6 +14,10 @@ from shared.decorators import validate_game_request
 sqs_client = boto3.client("sqs")
 REACTION_QUEUE_NAME = os.environ.get("reaction_queue_name")
 
+# Cached lazily on first use so the queue URL is resolved once per container
+# (and captured by the SnapStart snapshot) instead of on every reaction sent.
+_reaction_queue_url = None
+
 pattern = r"^(😮|🤨|👏|😂|🦊|👍|😑|😎|😅|😭|⏳|👋|🔥|👀|🤔|🤬|😈|😇|✔️|✖️)$"
 
 def is_safe_message(message):
@@ -22,12 +26,16 @@ def is_safe_message(message):
 
 def get_reaction_queue_url():
     """
-    Returns the URL of an existing Amazon SQS queue.
+    Returns the URL of an existing Amazon SQS queue, caching it after the
+    first successful lookup to avoid a GetQueueUrl call on every invocation.
     """
-    try:
-        return sqs_client.get_queue_url(QueueName=REACTION_QUEUE_NAME)['QueueUrl']
-    except ClientError:
-        return
+    global _reaction_queue_url
+    if _reaction_queue_url is None:
+        try:
+            _reaction_queue_url = sqs_client.get_queue_url(QueueName=REACTION_QUEUE_NAME)['QueueUrl']
+        except ClientError:
+            return None
+    return _reaction_queue_url
 
 
 def send_queue_message(message):

--- a/api/watch-chat.py
+++ b/api/watch-chat.py
@@ -1,8 +1,9 @@
 import os
 import boto3
 from boto3.dynamodb.conditions import Key
+from concurrent.futures import ThreadPoolExecutor
 import json
-from shared.response import * 
+from shared.response import *
 from shared.api_gateway import parse_event
 from shared.logging import logger
 from shared.db import websocket_table, get_from_dynamodb
@@ -14,13 +15,22 @@ watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage"
 endpoint_url = f"{boto3.client('apigatewayv2').get_api(ApiId=watch_game_websocket_api_id).get('ApiEndpoint')}/{watch_game_websocket_api_stage}".replace("wss://", "https://")
 apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
 
+# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
+# network-bound, so threads parallelise well despite the GIL.
+MAX_BROADCAST_WORKERS = 16
+
 def post_to_connection(payload, connection_id):
     logger.info('## POSTING TO CONNECTION')
     logger.info(connection_id)
-    response = apigateway.post_to_connection(
-        Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
-        ConnectionId=connection_id
-    )
+    try:
+        apigateway.post_to_connection(
+            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
+            ConnectionId=connection_id
+        )
+    except Exception as err:
+        # A single stale/gone connection must not abort the rest of the broadcast.
+        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
+        logger.info(str(err))
     return True
 
 
@@ -40,18 +50,25 @@ def broadcast_reaction(reaction_details):
         IndexName="game_uuid-index"
     )
     connections = [conn for conn in response.get("Items", []) if conn.get("reactions_enabled") == "true"]
-    
+
+    target_connection_ids = []
     for connection in connections:
         if target_team:
             player_uuid = connection.get("player_uuid")
             if not player_uuid:
                 continue # Observers don't get team-only reactions
-                
+
             player = next((p for p in game_players if p["uuid"] == player_uuid), None)
             if not player or player.get("team") != target_team:
                 continue # Skip players not on the target team
-                
-        post_to_connection(reaction_details, connection["connection_id"]) 
+
+        target_connection_ids.append(connection["connection_id"])
+
+    if not target_connection_ids:
+        return
+
+    with ThreadPoolExecutor(max_workers=min(len(target_connection_ids), MAX_BROADCAST_WORKERS)) as executor:
+        list(executor.map(lambda connection_id: post_to_connection(reaction_details, connection_id), target_connection_ids))
 
 def lambda_handler(event, context): 
     logger.info('## EVENT') 

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -2,8 +2,9 @@ import os
 import boto3
 from boto3.dynamodb.conditions import Key, Attr
 from botocore.exceptions import ClientError
+from concurrent.futures import ThreadPoolExecutor
 import json
-from shared.response import * 
+from shared.response import *
 from shared.api_gateway import parse_event
 from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, is_update_redundant
 from shared.logging import logger
@@ -11,6 +12,14 @@ from shared.db import websocket_table
 
 sqs_client = boto3.client("sqs")
 AIAGENT_QUEUE_NAME = os.environ.get("aiagent_queue_name")
+
+# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
+# network-bound, so threads parallelise well despite the GIL.
+MAX_BROADCAST_WORKERS = 16
+
+# Cached lazily on first use so the queue URL is resolved once per container
+# (and captured by the SnapStart snapshot) instead of on every broadcast.
+_aiagent_queue_url = None
 
 watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
 watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
@@ -23,12 +32,16 @@ deserializer = boto3.dynamodb.types.TypeDeserializer()
 
 def get_aiagent_queue_url():
     """
-    Returns the URL of an existing Amazon SQS queue.
+    Returns the URL of an existing Amazon SQS queue, caching it after the
+    first successful lookup to avoid a GetQueueUrl call on every invocation.
     """
-    try:
-        return sqs_client.get_queue_url(QueueName=AIAGENT_QUEUE_NAME)['QueueUrl']
-    except ClientError:
-        return
+    global _aiagent_queue_url
+    if _aiagent_queue_url is None:
+        try:
+            _aiagent_queue_url = sqs_client.get_queue_url(QueueName=AIAGENT_QUEUE_NAME)['QueueUrl']
+        except ClientError:
+            return None
+    return _aiagent_queue_url
 
 
 def send_queue_message(game):
@@ -107,9 +120,16 @@ def update_game_watchers(game):
     connected_players = find_connected_players(game)
     logger.info('## CONNECTED PLAYERS')
     logger.info(connected_players)
-    for connection_id, player_uuid in connected_players:
+    if not connected_players:
+        return
+
+    def post_player_update(connected_player):
+        connection_id, player_uuid = connected_player
         player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
         post_to_connection(censor_game(game, player_nickname), connection_id)
+
+    with ThreadPoolExecutor(max_workers=min(len(connected_players), MAX_BROADCAST_WORKERS)) as executor:
+        list(executor.map(post_player_update, connected_players))
 
 
 def update_public_games_watchers(game, game_old):
@@ -117,9 +137,11 @@ def update_public_games_watchers(game, game_old):
     if not can_get_public_info(game, game_old):
         return
     connected_watchers = find_connected_public_games_watchers()
-    for connection_id in connected_watchers:
-        public_game_info = get_public_game_info(game)
-        post_to_connection(public_game_info, connection_id)    
+    if not connected_watchers:
+        return
+    public_game_info = get_public_game_info(game)
+    with ThreadPoolExecutor(max_workers=min(len(connected_watchers), MAX_BROADCAST_WORKERS)) as executor:
+        list(executor.map(lambda connection_id: post_to_connection(public_game_info, connection_id), connected_watchers))
 
 
 def update_watchers(game):


### PR DESCRIPTION
## What & why

Two avoidable latency sources on the realtime (WebSocket) path, found while investigating slow emoji delivery and state-update propagation.

### 1. Sequential broadcasts → parallel
`watch-game-stream` (state updates) and `watch-chat` (reactions) posted to each connected client **one at a time** in a loop, so broadcast latency grew linearly with the number of connected clients (up to 8 players + observers). Now fanned out with a `ThreadPoolExecutor` (cap 16) — `PostToConnection` is network-bound, so threads parallelise well despite the GIL.

`watch-chat`'s `post_to_connection` now also **swallows per-connection errors** so a single stale/gone connection can't abort the rest of the broadcast (matches `watch-game-stream`'s existing behaviour).

### 2. Repeated `GetQueueUrl` → cached
`get_reaction_queue_url` (send-reaction) and `get_aiagent_queue_url` (watch-game-stream) called SQS `GetQueueUrl` on **every invocation** — `send-reaction` did it **twice per call** (once just to log it). Now cached at module scope after the first lookup: removes a network round-trip from the hot path and lets SnapStart capture the resolved URL in the snapshot.

Also hoisted `get_public_game_info(game)` out of the per-connection loop in `update_public_games_watchers` — it's identical for every watcher.

## Files
- `api/watch-game-stream.py` — parallel broadcast (both player + public-lobby loops), cached AI-agent queue URL, hoisted public-info.
- `api/watch-chat.py` — parallel broadcast, resilient `post_to_connection`.
- `api/send-reaction.py` — cached reaction queue URL.

## Testing
⚠️ The broadcast path is SQS/Stream-triggered and requires connected WebSocket clients, so it is **not** covered by the existing integration tests (`api/test/test_validation.py`, which hit the HTTP API). `py_compile` passes. **Please verify against a live game with multiple connected clients** before relying on this.

## Related
Complements the memory bumps applied to `send-reaction`, `watch-chat`, and `invite-aiagent` (512 MB), and the SnapStart/`prod`-alias wiring in #223. Those are infra changes; this PR is the code-level half of the realtime latency work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)