### PR TITLE
Add engine-side player avatars

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@
   `"nickname"=string`
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
-  `"avatar_spirit"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_crown"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
+  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
 
 * **URL Params**
 
@@ -54,7 +54,7 @@ curl <HOST>/games/create
 
   **Optional:**
 
-  `"avatar_spirit"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_crown"=string` (see [Avatars](#avatars))
+  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
 
 * **Success Response:**
 
@@ -69,27 +69,27 @@ curl <HOST>/games/create
 * **Sample Call:**
 
 ```
-curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_spirit=leshy&avatar_colour=moss&avatar_eyes=glowing&avatar_crown=antlers
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=wolf&avatar_colour=madder&avatar_eyes=narrow&avatar_hat=wreath
 ```
 
 ### Avatars
 
-Human players have a cosmetic **avatar** themed around Old Slavic deities and forest spirits — you pick which **spirit** you are, its natural **colour**, its **eyes** (gaze), and a woodland **crown**. Four independent slots, each set to one token from a fixed vocabulary:
+Human players are mortals seated at the gods' table, dressed in Slavic folk costume (Koliada mummery) — you pick an animal **mask**, the **colour** of your dyed homespun, your **eyes** (a bluff tell), and a woven **charm**. (The deities and forest spirits are the AI opponents, who carry their own bespoke art.) Four independent slots, each set to one token from a fixed vocabulary:
 
-| Slot   | Param            | Tokens                                                                                                                                  |
-|--------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Spirit | `avatar_spirit`  | `leshy` (forest guardian), `rusalka` (water nymph), `domovoi` (hearth spirit), `vila` (meadow fae), `veles` (earth/forest god), `mokosh` (earth mother) |
-| Colour | `avatar_colour`  | `moss`, `bark`, `amber`, `birch`, `river`, `berry`                                                                                     |
-| Eyes   | `avatar_eyes`    | `calm`, `merry`, `wise`, `fierce`, `glowing`, `closed`                                                                                 |
-| Crown  | `avatar_crown`   | `bare`, `antlers`, `wreath`, `oak`, `mushroom`, `feathers`                                                                             |
+| Slot   | Param           | Tokens                                                                                                            |
+|--------|-----------------|------------------------------------------------------------------------------------------------------------------|
+| Mask   | `avatar_base`   | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`                                                         |
+| Colour | `avatar_colour` | `linen` (undyed), `madder` (red), `woad` (blue), `birch` (yellow-green), `ochre` (earth gold), `soot` (charcoal)  |
+| Eyes   | `avatar_eyes`   | `calm`, `wink`, `narrow`, `wide`, `weary`, `bright`                                                               |
+| Charm  | `avatar_hat`    | `bare` (none), `wreath`, `antlers`, `feather`, `ribbons`, `bells`                                                 |
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 
 * An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting all four yields a fully random avatar.
-* To request an uncrowned avatar, send `avatar_crown=bare` explicitly (omitting `avatar_crown` randomises the crown instead).
-* An out-of-vocabulary token (e.g. `avatar_crown=sombrero`) returns **400 BAD REQUEST**.
+* To request a bare-headed avatar, send `avatar_hat=bare` explicitly (omitting `avatar_hat` randomises the charm instead).
+* An out-of-vocabulary token (e.g. `avatar_hat=tophat`) returns **400 BAD REQUEST**.
 
-The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"spirit": "leshy", "colour": "moss", "eyes": "glowing", "crown": "antlers"}`. AI players have **no** `avatar` field.
+The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"}`. AI players have **no** `avatar` field.
 
 ## Invite AI agent
 
@@ -347,7 +347,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"spirit": "leshy", "colour": "moss", "eyes": "glowing", "crown": "antlers"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 

--- a/api/README.md
+++ b/api/README.md
@@ -81,7 +81,7 @@ Each human player is a Slavic ritual **mask** of an animal, carved or cast in a 
 | Mask     | `avatar_mask`     | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`, `lynx`, `zubr` (European bison)    |
 | Material | `avatar_material` | `wood`, `stone`, `steel`, `gold`, `brass`, `amber`                                            |
 
-No human face or skin is shown — it is a mask object, and the material is a surface finish (wood, stone, metal, resin), not a skin tone or a flat colour, so it never reads as a team allegiance (teams are a separate coloured glow, defined in the clients). The masks are plain beasts, not the deity-named AI opponents, so these tokens never collide with agent names.
+No human face or skin is shown — the avatar is a mask object, and the material is a surface finish (wood, stone, metal, resin) rather than a flat colour. The engine stores only the tokens; how an avatar is drawn is left to the API consumer. Material is intentionally a finish, not a colour, so an avatar won't collide with separate colour-coded concepts such as team membership. The mask and material tokens are also kept distinct from the AI agent names, so an avatar can't be confused with an agent.
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 

--- a/api/README.md
+++ b/api/README.md
@@ -81,9 +81,9 @@ Human players are mortals at the gods' table in Slavic folk costume (Koliada mum
 | Mask  | `avatar_base`  | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`                                                       |
 | Cloth | `avatar_cloth` | `poppy` (red), `cherry` (deep red), `chestnut` (brown), `wheat` (straw gold), `linen` (natural), `coal` (black) |
 | Eyes  | `avatar_eyes`  | `calm`, `wink`, `narrow`, `wide`, `weary`, `bright`                                                             |
-| Charm | `avatar_hat`   | `bare` (none), `wreath`, `antlers`, `feather`, `ribbons`, `bells`                                               |
+| Charm | `avatar_hat`   | `bare` (none), `wreath`, `kerchief`, `ribbons`, `bells`, `coins`                                          |
 
-Team allegiance is shown separately as a coloured glow behind the avatar (teams are blue / green / purple / orange — defined in the clients, not the engine). The cloth palette is deliberately warm folk tones that avoid those hues, so a player's personal flair never reads as a team colour.
+Team allegiance is shown separately as a coloured glow behind the avatar (teams are blue / green / purple / orange — defined in the clients, not the engine). The cloth palette is deliberately warm folk tones that avoid those hues, so a player's personal flair never reads as a team colour. The slots compose on any mask: the mask carries the creature's own features (horns, beak, feathers) and the eyes show through its eye-holes, so the charm slot is human-made folk adornments — never animal features — which never clash with a horned or bird mask.
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 

--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@
   `"nickname"=string`
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
-  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
+  `"avatar_base"=string`, `"avatar_cloth"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
 
 * **URL Params**
 
@@ -54,7 +54,7 @@ curl <HOST>/games/create
 
   **Optional:**
 
-  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
+  `"avatar_base"=string`, `"avatar_cloth"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
 
 * **Success Response:**
 
@@ -69,27 +69,29 @@ curl <HOST>/games/create
 * **Sample Call:**
 
 ```
-curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=wolf&avatar_colour=madder&avatar_eyes=narrow&avatar_hat=wreath
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=wolf&avatar_cloth=poppy&avatar_eyes=narrow&avatar_hat=wreath
 ```
 
 ### Avatars
 
-Human players are mortals seated at the gods' table, dressed in Slavic folk costume (Koliada mummery) — you pick an animal **mask**, the **colour** of your dyed homespun, your **eyes** (a bluff tell), and a woven **charm**. (The deities and forest spirits are the AI opponents, who carry their own bespoke art.) Four independent slots, each set to one token from a fixed vocabulary:
+Human players are mortals at the gods' table in Slavic folk costume (Koliada mummery) — you pick an animal **mask**, the **cloth** colour of your dyed homespun, your **eyes** (a bluff tell), and a woven **charm**. The face is a mask, so no human skin is shown; the cloth colour is personal flair, **not** a skin tone. (The deities and forest spirits are the AI opponents, with their own bespoke art.) Four independent slots, each one token from a fixed vocabulary:
 
-| Slot   | Param           | Tokens                                                                                                            |
-|--------|-----------------|------------------------------------------------------------------------------------------------------------------|
-| Mask   | `avatar_base`   | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`                                                         |
-| Colour | `avatar_colour` | `linen` (undyed), `madder` (red), `woad` (blue), `birch` (yellow-green), `ochre` (earth gold), `soot` (charcoal)  |
-| Eyes   | `avatar_eyes`   | `calm`, `wink`, `narrow`, `wide`, `weary`, `bright`                                                               |
-| Charm  | `avatar_hat`    | `bare` (none), `wreath`, `antlers`, `feather`, `ribbons`, `bells`                                                 |
+| Slot  | Param          | Tokens                                                                                                         |
+|-------|----------------|----------------------------------------------------------------------------------------------------------------|
+| Mask  | `avatar_base`  | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`                                                       |
+| Cloth | `avatar_cloth` | `poppy` (red), `cherry` (deep red), `chestnut` (brown), `wheat` (straw gold), `linen` (natural), `coal` (black) |
+| Eyes  | `avatar_eyes`  | `calm`, `wink`, `narrow`, `wide`, `weary`, `bright`                                                             |
+| Charm | `avatar_hat`   | `bare` (none), `wreath`, `antlers`, `feather`, `ribbons`, `bells`                                               |
+
+Team allegiance is shown separately as a coloured glow behind the avatar (teams are blue / green / purple / orange — defined in the clients, not the engine). The cloth palette is deliberately warm folk tones that avoid those hues, so a player's personal flair never reads as a team colour.
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 
 * An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting all four yields a fully random avatar.
-* To request a bare-headed avatar, send `avatar_hat=bare` explicitly (omitting `avatar_hat` randomises the charm instead).
+* To request a bare-headed avatar, send `avatar_hat=bare` explicitly (omitting `avatar_hat` randomises the charm).
 * An out-of-vocabulary token (e.g. `avatar_hat=tophat`) returns **400 BAD REQUEST**.
 
-The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"}`. AI players have **no** `avatar` field.
+The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"}`. AI players have **no** `avatar` field.
 
 ## Invite AI agent
 
@@ -347,7 +349,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 

--- a/api/README.md
+++ b/api/README.md
@@ -15,6 +15,7 @@
   `"nickname"=string`
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
+  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
 
 * **URL Params**
 
@@ -51,6 +52,10 @@ curl <HOST>/games/create
 
   `"nickname"=string`
 
+  **Optional:**
+
+  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
+
 * **Success Response:**
 
   * **Code:** 200 OK <br />
@@ -64,8 +69,27 @@ curl <HOST>/games/create
 * **Sample Call:**
 
 ```
-curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=round&avatar_colour=blue&avatar_eyes=sunglasses&avatar_hat=crown
 ```
+
+### Avatars
+
+Human players have a cosmetic **avatar** made of four independent slots, each set to one token from a fixed vocabulary:
+
+| Slot           | Param            | Tokens                                                  |
+|----------------|------------------|--------------------------------------------------------|
+| Base smiley    | `avatar_base`    | `classic`, `round`, `square`, `oval`, `pixel`, `retro` |
+| Colour         | `avatar_colour`  | `yellow`, `blue`, `green`, `pink`, `purple`, `orange`  |
+| Eyes           | `avatar_eyes`    | `plain`, `sunglasses`, `glasses`, `wink`, `stars`, `sleepy` |
+| Hat            | `avatar_hat`     | `none`, `cap`, `crown`, `party`, `beanie`, `halo`      |
+
+The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
+
+* An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting all four yields a fully random avatar.
+* To request a bare-headed avatar, send `avatar_hat=none` explicitly (omitting `avatar_hat` randomises the hat instead).
+* An out-of-vocabulary token (e.g. `avatar_hat=sombrero`) returns **400 BAD REQUEST**.
+
+The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"}`. AI players have **no** `avatar` field.
 
 ## Invite AI agent
 
@@ -323,7 +347,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin"}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 

--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@
   `"nickname"=string`
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
-  `"avatar_base"=string`, `"avatar_cloth"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
+  `"avatar_mask"=string`, `"avatar_material"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
 
 * **URL Params**
 
@@ -54,7 +54,7 @@ curl <HOST>/games/create
 
   **Optional:**
 
-  `"avatar_base"=string`, `"avatar_cloth"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
+  `"avatar_mask"=string`, `"avatar_material"=string` (see [Avatars](#avatars))
 
 * **Success Response:**
 
@@ -69,29 +69,26 @@ curl <HOST>/games/create
 * **Sample Call:**
 
 ```
-curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=wolf&avatar_cloth=poppy&avatar_eyes=narrow&avatar_hat=wreath
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_mask=wolf&avatar_material=amber
 ```
 
 ### Avatars
 
-Human players are mortals at the gods' table in Slavic folk costume (Koliada mummery) — you pick an animal **mask**, the **cloth** colour of your dyed homespun, your **eyes** (a bluff tell), and a woven **charm**. The face is a mask, so no human skin is shown; the cloth colour is personal flair, **not** a skin tone. (The deities and forest spirits are the AI opponents, with their own bespoke art.) Four independent slots, each one token from a fixed vocabulary:
+Each human player is a Slavic ritual **mask** of an animal, carved or cast in a **material**. Just two slots, each one token from a fixed vocabulary (8 × 6 = 48 combinations):
 
-| Slot  | Param          | Tokens                                                                                                         |
-|-------|----------------|----------------------------------------------------------------------------------------------------------------|
-| Mask  | `avatar_base`  | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`                                                       |
-| Cloth | `avatar_cloth` | `poppy` (red), `cherry` (deep red), `chestnut` (brown), `wheat` (straw gold), `linen` (natural), `coal` (black) |
-| Eyes  | `avatar_eyes`  | `calm`, `wink`, `narrow`, `wide`, `weary`, `bright`                                                             |
-| Charm | `avatar_hat`   | `bare` (none), `wreath`, `kerchief`, `ribbons`, `bells`, `coins`                                          |
+| Slot     | Param             | Tokens                                                                                       |
+|----------|-------------------|----------------------------------------------------------------------------------------------|
+| Mask     | `avatar_mask`     | `tur` (aurochs), `bear`, `goat`, `stork`, `wolf`, `raven`, `lynx`, `zubr` (European bison)    |
+| Material | `avatar_material` | `wood`, `stone`, `steel`, `gold`, `brass`, `amber`                                            |
 
-Team allegiance is shown separately as a coloured glow behind the avatar (teams are blue / green / purple / orange — defined in the clients, not the engine). The cloth palette is deliberately warm folk tones that avoid those hues, so a player's personal flair never reads as a team colour. The slots compose on any mask: the mask carries the creature's own features (horns, beak, feathers) and the eyes show through its eye-holes, so the charm slot is human-made folk adornments — never animal features — which never clash with a horned or bird mask.
+No human face or skin is shown — it is a mask object, and the material is a surface finish (wood, stone, metal, resin), not a skin tone or a flat colour, so it never reads as a team allegiance (teams are a separate coloured glow, defined in the clients). The masks are plain beasts, not the deity-named AI opponents, so these tokens never collide with agent names.
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 
-* An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting all four yields a fully random avatar.
-* To request a bare-headed avatar, send `avatar_hat=bare` explicitly (omitting `avatar_hat` randomises the charm).
-* An out-of-vocabulary token (e.g. `avatar_hat=tophat`) returns **400 BAD REQUEST**.
+* An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting both yields a fully random avatar.
+* An out-of-vocabulary token (e.g. `avatar_material=plastic`) returns **400 BAD REQUEST**.
 
-The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"}`. AI players have **no** `avatar` field.
+The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"mask": "wolf", "material": "amber"}`. AI players have **no** `avatar` field.
 
 ## Invite AI agent
 
@@ -349,7 +346,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"mask": "wolf", "material": "amber"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 

--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@
   `"nickname"=string`
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
-  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
+  `"avatar_spirit"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_crown"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
 
 * **URL Params**
 
@@ -54,7 +54,7 @@ curl <HOST>/games/create
 
   **Optional:**
 
-  `"avatar_base"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_hat"=string` (see [Avatars](#avatars))
+  `"avatar_spirit"=string`, `"avatar_colour"=string`, `"avatar_eyes"=string`, `"avatar_crown"=string` (see [Avatars](#avatars))
 
 * **Success Response:**
 
@@ -69,27 +69,27 @@ curl <HOST>/games/create
 * **Sample Call:**
 
 ```
-curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_base=round&avatar_colour=blue&avatar_eyes=sunglasses&avatar_hat=crown
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_spirit=leshy&avatar_colour=moss&avatar_eyes=glowing&avatar_crown=antlers
 ```
 
 ### Avatars
 
-Human players have a cosmetic **avatar** made of four independent slots, each set to one token from a fixed vocabulary:
+Human players have a cosmetic **avatar** themed around Old Slavic deities and forest spirits — you pick which **spirit** you are, its natural **colour**, its **eyes** (gaze), and a woodland **crown**. Four independent slots, each set to one token from a fixed vocabulary:
 
-| Slot           | Param            | Tokens                                                  |
-|----------------|------------------|--------------------------------------------------------|
-| Base smiley    | `avatar_base`    | `classic`, `round`, `square`, `oval`, `pixel`, `retro` |
-| Colour         | `avatar_colour`  | `yellow`, `blue`, `green`, `pink`, `purple`, `orange`  |
-| Eyes           | `avatar_eyes`    | `plain`, `sunglasses`, `glasses`, `wink`, `stars`, `sleepy` |
-| Hat            | `avatar_hat`     | `none`, `cap`, `crown`, `party`, `beanie`, `halo`      |
+| Slot   | Param            | Tokens                                                                                                                                  |
+|--------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| Spirit | `avatar_spirit`  | `leshy` (forest guardian), `rusalka` (water nymph), `domovoi` (hearth spirit), `vila` (meadow fae), `veles` (earth/forest god), `mokosh` (earth mother) |
+| Colour | `avatar_colour`  | `moss`, `bark`, `amber`, `birch`, `river`, `berry`                                                                                     |
+| Eyes   | `avatar_eyes`    | `calm`, `merry`, `wise`, `fierce`, `glowing`, `closed`                                                                                 |
+| Crown  | `avatar_crown`   | `bare`, `antlers`, `wreath`, `oak`, `mushroom`, `feathers`                                                                             |
 
 The avatar is set once, when the player is created (on **Join game**, or on **Create game** when a `nickname` is supplied). It cannot be changed afterwards. Each slot is optional:
 
 * An omitted slot is filled with a random token (so players who don't customise are still visually distinct). Omitting all four yields a fully random avatar.
-* To request a bare-headed avatar, send `avatar_hat=none` explicitly (omitting `avatar_hat` randomises the hat instead).
-* An out-of-vocabulary token (e.g. `avatar_hat=sombrero`) returns **400 BAD REQUEST**.
+* To request an uncrowned avatar, send `avatar_crown=bare` explicitly (omitting `avatar_crown` randomises the crown instead).
+* An out-of-vocabulary token (e.g. `avatar_crown=sombrero`) returns **400 BAD REQUEST**.
 
-The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"}`. AI players have **no** `avatar` field.
+The chosen avatar is stored on the player and returned in game state as a nested object, e.g. a player entry includes `"avatar": {"spirit": "leshy", "colour": "moss", "eyes": "glowing", "crown": "antlers"}`. AI players have **no** `avatar` field.
 
 ## Invite AI agent
 
@@ -347,7 +347,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/start?admin_uuid=a6a53849
 * **Success Response:**
 
   * **Code:** 200 OK <br />
-  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
+  **Content:** `{"admin_nickname": "MyAdmin", "public": "false", "room": 80, "status": "Running", "round_number": 2, "max_cards": 8, "players": [{"ready": true, "n_cards": 1, "nickname": "MyAdmin", "avatar": {"spirit": "leshy", "colour": "moss", "eyes": "glowing", "crown": "antlers"}}, {"ready": true, "nickname": "Porevit_(AI)", "n_cards": 2, "ai_agent": "conservative-crawling"}, {"ready": true, "nickname": "Porevit_2_(AI)", "n_cards": 1, "ai_agent": "conservative-crawling"}], "hands": [{"nickname": "MyAdmin", "hand": [{"colour": 2, "value": 3}]}], "common_hand": [], "cp_nickname": "MyAdmin", "history": [{"action_id": 1, "player": "Porevit_(AI)"}, {"action_id": 4, "player": "Porevit_2_(AI)"}], "last_modified": 1755801637.4618988, "rules": {"jokers": 0, "time_limit": 0, "deck_size": 24, "blanks": 0, "max_cards_preference": 9, "common_cards": 0}, "move_deadline": null, "update_time": 1755801637.9895098}`
 
 * **Sample Error Response:**
 

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -6,7 +6,7 @@ import time
 from botocore.exceptions import ClientError
 from shared.response import error_payload, internal_error_payload, parameter_error_payload, request_error_payload, response_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
-from shared.constants import GameStatus, RuleValues
+from shared.constants import GameStatus, RuleValues, validate_avatar
 from shared.db import get_from_dynamodb, save_in_dynamodb, table
 from shared.game import create_player
 from shared.api_gateway import parse_event
@@ -116,7 +116,11 @@ def lambda_handler(event, context):
         if is_offensive(nickname):
             return nickname_rejected_payload(reason="profanity")
 
-        player = create_player(game, nickname)
+        avatar, avatar_error = validate_avatar(body)
+        if avatar_error:
+            return parameter_error_payload("avatar", None, message=avatar_error)
+
+        player = create_player(game, nickname, avatar)
         game.update({"players": [player], "admin_nickname": player.get("nickname")})
         if save_in_dynamodb(game):
             return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player.get("uuid")})

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
 from shared.db import table
-from shared.constants import GameStatus
+from shared.constants import GameStatus, validate_avatar
 from shared.game import create_player, calculate_actual_max_cards
 from shared.decorators import validate_game_request
 from shared.logging import logger
@@ -58,7 +58,11 @@ def lambda_handler(event, context, body, game):
         if nickname in [p["nickname"] for p in players]:
             return parameter_error_payload("nickname", nickname, message="Nickname already taken")
 
-        new_player = create_player(game, nickname)
+        avatar, avatar_error = validate_avatar(body)
+        if avatar_error:
+            return parameter_error_payload("avatar", None, message=avatar_error)
+
+        new_player = create_player(game, nickname, avatar)
         players.append(new_player)
         admin_nickname = game.get("admin_nickname") or new_player.get("nickname")
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -69,22 +69,15 @@ class SpecialNicknames:
 class AvatarSlots:
     """Fixed cosmetic vocabulary for player avatars.
 
-    Players are mortals at the gods' table in Slavic folk costume (Koliada
-    mummery): an animal-mask face, dyed homespun cloth, a bluff-tell gaze, and
-    a woven charm. No human skin is ever shown (the face is a mask), so the
-    'cloth' slot is the costume colour - personal flair, not a skin tone.
+    Each human player is a Slavic ritual animal mask, carved or cast in a
+    chosen material - two slots only: the mask (which beast) and the material
+    (its finish). No human face or skin is shown; the material is a surface
+    (wood, stone, metal, resin), not a skin tone or a flat colour, so it never
+    reads as a team-glow allegiance.
 
-    The slots compose on any mask: the mask carries the creature's own features
-    (horns, beak, feathers) and the eyes show through its eye-holes, so the
-    'hat' charm stays human-made folk adornments (no antlers/feathers) that
-    never clash with a horned or bird mask.
-
-    Cloth tones are deliberately warm folk colours that avoid the team-glow
-    hues (teams are blue/green/purple/orange), so a player's flair never reads
-    as a team allegiance.
-
-    They are deliberately NOT deities - the named AI agents are the gods/spirits
-    and carry their own bespoke art, so these tokens never reuse those names.
+    The masks are plain beasts, not deities - the named AI agents are the
+    gods/spirits and carry their own bespoke art, so these tokens never reuse
+    those names.
 
     The engine is an opaque carrier: it validates that each chosen token is in
     the agreed vocabulary, stores it, and broadcasts it. It never interprets or
@@ -93,12 +86,10 @@ class AvatarSlots:
     agree between engine and clients. Grow the tuples by appending if needed.
     """
     OPTIONS = {
-        "base":  ("tur", "bear", "goat", "stork", "wolf", "raven"),
-        "cloth": ("poppy", "cherry", "chestnut", "wheat", "linen", "coal"),
-        "eyes":  ("calm", "wink", "narrow", "wide", "weary", "bright"),
-        "hat":   ("bare", "wreath", "kerchief", "ribbons", "bells", "coins"),
+        "mask":     ("tur", "bear", "goat", "stork", "wolf", "raven", "lynx", "zubr"),
+        "material": ("wood", "stone", "steel", "gold", "brass", "amber"),
     }
-    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_cloth, ...
+    PARAM_PREFIX = "avatar_"  # wire param names: avatar_mask, avatar_material
 
 def random_avatar():
     """Returns a fully random, valid avatar - one token per slot."""
@@ -107,8 +98,8 @@ def random_avatar():
 def validate_avatar(body):
     """Builds a player's avatar from flat avatar_<slot> request params.
 
-    Clients transmit avatars as flat query-string params (avatar_base,
-    avatar_cloth, ...) because the GET endpoints cannot carry a nested object.
+    Clients transmit avatars as flat query-string params (avatar_mask,
+    avatar_material) because the GET endpoints cannot carry a nested object.
     Provided slots are validated against the vocabulary; omitted slots are
     randomly filled so un-customised players are still distinct. Unrelated
     params are ignored (only the four known slot keys are read).

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -69,21 +69,25 @@ class SpecialNicknames:
 class AvatarSlots:
     """Fixed cosmetic vocabulary for player avatars.
 
-    Each human player is a Slavic ritual animal mask, carved or cast in a
-    chosen material - two slots only: the mask (which beast) and the material
-    (its finish). No human face or skin is shown; the material is a surface
-    (wood, stone, metal, resin), not a skin tone or a flat colour, so it never
-    reads as a team-glow allegiance.
+    Two slots: the mask (which animal) and the material it is carved or cast
+    in. The engine is an opaque carrier - it validates that each token is in
+    the vocabulary, stores it on the player, and broadcasts it. It never
+    interprets or renders the tokens; the rendered appearance is left to
+    whatever consumes the API, which maps these tokens to its own art. Only the
+    token strings form the contract.
 
-    The masks are plain beasts, not deities - the named AI agents are the
-    gods/spirits and carry their own bespoke art, so these tokens never reuse
-    those names.
+    A few deliberate constraints, recorded to prevent later mistakes:
+    - Material is a surface/finish (wood, stone, metal, resin), not a flat
+      colour. Keeping appearance out of the engine leaves colour choices to the
+      consumer and avoids tokens that could collide with separate colour-coded
+      concepts such as team membership.
+    - The model shows a mask object, never a human face, so no token implies a
+      skin tone.
+    - Mask and material tokens are kept distinct from the AI agent names (see
+      the invite-aiagent agent mapping) so a player avatar can't be confused
+      with an agent.
 
-    The engine is an opaque carrier: it validates that each chosen token is in
-    the agreed vocabulary, stores it, and broadcasts it. It never interprets or
-    renders the tokens - the clients map them to art. Token names are
-    placeholders for the clients/product to finalise; only the strings must
-    agree between engine and clients. Grow the tuples by appending if needed.
+    Grow the tuples by appending if needed.
     """
     OPTIONS = {
         "mask":     ("tur", "bear", "goat", "stork", "wolf", "raven", "lynx", "zubr"),
@@ -98,11 +102,11 @@ def random_avatar():
 def validate_avatar(body):
     """Builds a player's avatar from flat avatar_<slot> request params.
 
-    Clients transmit avatars as flat query-string params (avatar_mask,
-    avatar_material) because the GET endpoints cannot carry a nested object.
-    Provided slots are validated against the vocabulary; omitted slots are
-    randomly filled so un-customised players are still distinct. Unrelated
-    params are ignored (only the four known slot keys are read).
+    Avatars arrive as flat query-string params (avatar_mask, avatar_material):
+    the GET endpoints merge query params into `body`, and a flat param can't
+    carry a nested object. Provided slots are validated against the vocabulary;
+    omitted slots are randomly filled so un-customised players are still
+    distinct. Unrelated params are ignored (only the known slot keys are read).
 
     Returns (avatar_dict, None) on success or (None, error_message) on failure.
     """

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -74,6 +74,11 @@ class AvatarSlots:
     a woven charm. No human skin is ever shown (the face is a mask), so the
     'cloth' slot is the costume colour - personal flair, not a skin tone.
 
+    The slots compose on any mask: the mask carries the creature's own features
+    (horns, beak, feathers) and the eyes show through its eye-holes, so the
+    'hat' charm stays human-made folk adornments (no antlers/feathers) that
+    never clash with a horned or bird mask.
+
     Cloth tones are deliberately warm folk colours that avoid the team-glow
     hues (teams are blue/green/purple/orange), so a player's flair never reads
     as a team allegiance.
@@ -91,7 +96,7 @@ class AvatarSlots:
         "base":  ("tur", "bear", "goat", "stork", "wolf", "raven"),
         "cloth": ("poppy", "cherry", "chestnut", "wheat", "linen", "coal"),
         "eyes":  ("calm", "wink", "narrow", "wide", "weary", "bright"),
-        "hat":   ("bare", "wreath", "antlers", "feather", "ribbons", "bells"),
+        "hat":   ("bare", "wreath", "kerchief", "ribbons", "bells", "coins"),
     }
     PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_cloth, ...
 

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -69,12 +69,17 @@ class SpecialNicknames:
 class AvatarSlots:
     """Fixed cosmetic vocabulary for player avatars.
 
-    Players are mortals at the gods' table, dressed in Slavic folk costume
-    (Koliada mummery): an animal mask, dyed homespun cloth, a bluff-tell gaze,
-    and a woven charm. They are deliberately NOT deities - the named AI agents
-    are the gods/spirits and carry their own bespoke art, so these tokens never
-    reuse those names. Slot keys stay generic (base/colour/eyes/hat); only the
-    token vocabulary is themed.
+    Players are mortals at the gods' table in Slavic folk costume (Koliada
+    mummery): an animal-mask face, dyed homespun cloth, a bluff-tell gaze, and
+    a woven charm. No human skin is ever shown (the face is a mask), so the
+    'cloth' slot is the costume colour - personal flair, not a skin tone.
+
+    Cloth tones are deliberately warm folk colours that avoid the team-glow
+    hues (teams are blue/green/purple/orange), so a player's flair never reads
+    as a team allegiance.
+
+    They are deliberately NOT deities - the named AI agents are the gods/spirits
+    and carry their own bespoke art, so these tokens never reuse those names.
 
     The engine is an opaque carrier: it validates that each chosen token is in
     the agreed vocabulary, stores it, and broadcasts it. It never interprets or
@@ -83,12 +88,12 @@ class AvatarSlots:
     agree between engine and clients. Grow the tuples by appending if needed.
     """
     OPTIONS = {
-        "base":   ("tur", "bear", "goat", "stork", "wolf", "raven"),
-        "colour": ("linen", "madder", "woad", "birch", "ochre", "soot"),
-        "eyes":   ("calm", "wink", "narrow", "wide", "weary", "bright"),
-        "hat":    ("bare", "wreath", "antlers", "feather", "ribbons", "bells"),
+        "base":  ("tur", "bear", "goat", "stork", "wolf", "raven"),
+        "cloth": ("poppy", "cherry", "chestnut", "wheat", "linen", "coal"),
+        "eyes":  ("calm", "wink", "narrow", "wide", "weary", "bright"),
+        "hat":   ("bare", "wreath", "antlers", "feather", "ribbons", "bells"),
     }
-    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_colour, ...
+    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_cloth, ...
 
 def random_avatar():
     """Returns a fully random, valid avatar - one token per slot."""
@@ -98,7 +103,7 @@ def validate_avatar(body):
     """Builds a player's avatar from flat avatar_<slot> request params.
 
     Clients transmit avatars as flat query-string params (avatar_base,
-    avatar_colour, ...) because the GET endpoints cannot carry a nested object.
+    avatar_cloth, ...) because the GET endpoints cannot carry a nested object.
     Provided slots are validated against the vocabulary; omitted slots are
     randomly filled so un-customised players are still distinct. Unrelated
     params are ignored (only the four known slot keys are read).

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -69,6 +69,9 @@ class SpecialNicknames:
 class AvatarSlots:
     """Fixed cosmetic vocabulary for player avatars.
 
+    Themed around Old Slavic deities and forest spirits: a player picks which
+    spirit they are, its natural colour, its gaze, and a woodland crown.
+
     The engine is an opaque carrier: it validates that each chosen token is in
     the agreed vocabulary, stores it, and broadcasts it. It never interprets or
     renders the tokens - the clients map them to art. Token names are
@@ -76,12 +79,12 @@ class AvatarSlots:
     agree between engine and clients. Grow the tuples by appending if needed.
     """
     OPTIONS = {
-        "base":   ("classic", "round", "square", "oval", "pixel", "retro"),
-        "colour": ("yellow", "blue", "green", "pink", "purple", "orange"),
-        "eyes":   ("plain", "sunglasses", "glasses", "wink", "stars", "sleepy"),
-        "hat":    ("none", "cap", "crown", "party", "beanie", "halo"),
+        "spirit": ("leshy", "rusalka", "domovoi", "vila", "veles", "mokosh"),
+        "colour": ("moss", "bark", "amber", "birch", "river", "berry"),
+        "eyes":   ("calm", "merry", "wise", "fierce", "glowing", "closed"),
+        "crown":  ("bare", "antlers", "wreath", "oak", "mushroom", "feathers"),
     }
-    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_colour, ...
+    PARAM_PREFIX = "avatar_"  # wire param names: avatar_spirit, avatar_colour, ...
 
 def random_avatar():
     """Returns a fully random, valid avatar - one token per slot."""
@@ -90,7 +93,7 @@ def random_avatar():
 def validate_avatar(body):
     """Builds a player's avatar from flat avatar_<slot> request params.
 
-    Clients transmit avatars as flat query-string params (avatar_base,
+    Clients transmit avatars as flat query-string params (avatar_spirit,
     avatar_colour, ...) because the GET endpoints cannot carry a nested object.
     Provided slots are validated against the vocabulary; omitted slots are
     randomly filled so un-customised players are still distinct. Unrelated

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -69,8 +69,12 @@ class SpecialNicknames:
 class AvatarSlots:
     """Fixed cosmetic vocabulary for player avatars.
 
-    Themed around Old Slavic deities and forest spirits: a player picks which
-    spirit they are, its natural colour, its gaze, and a woodland crown.
+    Players are mortals at the gods' table, dressed in Slavic folk costume
+    (Koliada mummery): an animal mask, dyed homespun cloth, a bluff-tell gaze,
+    and a woven charm. They are deliberately NOT deities - the named AI agents
+    are the gods/spirits and carry their own bespoke art, so these tokens never
+    reuse those names. Slot keys stay generic (base/colour/eyes/hat); only the
+    token vocabulary is themed.
 
     The engine is an opaque carrier: it validates that each chosen token is in
     the agreed vocabulary, stores it, and broadcasts it. It never interprets or
@@ -79,12 +83,12 @@ class AvatarSlots:
     agree between engine and clients. Grow the tuples by appending if needed.
     """
     OPTIONS = {
-        "spirit": ("leshy", "rusalka", "domovoi", "vila", "veles", "mokosh"),
-        "colour": ("moss", "bark", "amber", "birch", "river", "berry"),
-        "eyes":   ("calm", "merry", "wise", "fierce", "glowing", "closed"),
-        "crown":  ("bare", "antlers", "wreath", "oak", "mushroom", "feathers"),
+        "base":   ("tur", "bear", "goat", "stork", "wolf", "raven"),
+        "colour": ("linen", "madder", "woad", "birch", "ochre", "soot"),
+        "eyes":   ("calm", "wink", "narrow", "wide", "weary", "bright"),
+        "hat":    ("bare", "wreath", "antlers", "feather", "ribbons", "bells"),
     }
-    PARAM_PREFIX = "avatar_"  # wire param names: avatar_spirit, avatar_colour, ...
+    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_colour, ...
 
 def random_avatar():
     """Returns a fully random, valid avatar - one token per slot."""
@@ -93,7 +97,7 @@ def random_avatar():
 def validate_avatar(body):
     """Builds a player's avatar from flat avatar_<slot> request params.
 
-    Clients transmit avatars as flat query-string params (avatar_spirit,
+    Clients transmit avatars as flat query-string params (avatar_base,
     avatar_colour, ...) because the GET endpoints cannot carry a nested object.
     Provided slots are validated against the vocabulary; omitted slots are
     randomly filled so un-customised players are still distinct. Unrelated

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -1,3 +1,4 @@
+import random
 from enum import Enum
 
 class GameStatus:
@@ -64,3 +65,46 @@ class RuleValues:
 
 class SpecialNicknames:
     COMMON_HAND = "0"
+
+class AvatarSlots:
+    """Fixed cosmetic vocabulary for player avatars.
+
+    The engine is an opaque carrier: it validates that each chosen token is in
+    the agreed vocabulary, stores it, and broadcasts it. It never interprets or
+    renders the tokens - the clients map them to art. Token names are
+    placeholders for the clients/product to finalise; only the strings must
+    agree between engine and clients. Grow the tuples by appending if needed.
+    """
+    OPTIONS = {
+        "base":   ("classic", "round", "square", "oval", "pixel", "retro"),
+        "colour": ("yellow", "blue", "green", "pink", "purple", "orange"),
+        "eyes":   ("plain", "sunglasses", "glasses", "wink", "stars", "sleepy"),
+        "hat":    ("none", "cap", "crown", "party", "beanie", "halo"),
+    }
+    PARAM_PREFIX = "avatar_"  # wire param names: avatar_base, avatar_colour, ...
+
+def random_avatar():
+    """Returns a fully random, valid avatar - one token per slot."""
+    return {slot: random.choice(options) for slot, options in AvatarSlots.OPTIONS.items()}
+
+def validate_avatar(body):
+    """Builds a player's avatar from flat avatar_<slot> request params.
+
+    Clients transmit avatars as flat query-string params (avatar_base,
+    avatar_colour, ...) because the GET endpoints cannot carry a nested object.
+    Provided slots are validated against the vocabulary; omitted slots are
+    randomly filled so un-customised players are still distinct. Unrelated
+    params are ignored (only the four known slot keys are read).
+
+    Returns (avatar_dict, None) on success or (None, error_message) on failure.
+    """
+    avatar = {}
+    for slot, options in AvatarSlots.OPTIONS.items():
+        raw = body.get(AvatarSlots.PARAM_PREFIX + slot)
+        if raw is None:
+            avatar[slot] = random.choice(options)
+        elif isinstance(raw, str) and raw in options:
+            avatar[slot] = raw
+        else:
+            return None, f"Invalid value for '{AvatarSlots.PARAM_PREFIX + slot}'"
+    return avatar, None

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -9,17 +9,18 @@ import uuid
 from .db import table, save_in_dynamodb, transact_end_of_round
 from .time_limit import send_time_limit_message
 from .logging import logger
-from .constants import GameStatus, CommonCardsRules, RuleValues
+from .constants import GameStatus, CommonCardsRules, RuleValues, random_avatar
 
-def create_player(game, nickname):
+def create_player(game, nickname, avatar=None):
     players = game.get("players")
     ready = False if len(players) == 0 or game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_DEFAULT) != RuleValues.TIME_LIMIT_NO_LIMIT else True
     return {
-        "uuid": str(uuid.uuid4()), 
-        "nickname": nickname, 
-        "n_cards": 0, 
+        "uuid": str(uuid.uuid4()),
+        "nickname": nickname,
+        "n_cards": 0,
         "ready": ready,
-        "team": None
+        "team": None,
+        "avatar": avatar if avatar is not None else random_avatar()
     }
 
 def get_player_by_nickname(players, nickname):

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -31,39 +31,39 @@ class TestAvatarValidation(unittest.TestCase):
 
     def test_all_slots_provided_are_preserved(self):
         body = {
-            "avatar_spirit": "rusalka",
-            "avatar_colour": "river",
-            "avatar_eyes": "glowing",
-            "avatar_crown": "wreath",
+            "avatar_base": "wolf",
+            "avatar_colour": "madder",
+            "avatar_eyes": "narrow",
+            "avatar_hat": "wreath",
         }
         avatar, err = validate_avatar(body)
         self.assertIsNone(err)
         self.assertEqual(
             avatar,
-            {"spirit": "rusalka", "colour": "river", "eyes": "glowing", "crown": "wreath"},
+            {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"},
         )
 
     def test_partial_input_preserves_given_and_fills_rest(self):
-        avatar, err = validate_avatar({"avatar_crown": "antlers"})
+        avatar, err = validate_avatar({"avatar_hat": "antlers"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["crown"], "antlers")
+        self.assertEqual(avatar["hat"], "antlers")
         self.assertTrue(_is_valid_avatar(avatar))
 
-    def test_explicit_bare_crown_is_not_randomised(self):
-        # "bare" is a real token (no crown); it must be respected, not rerolled.
-        avatar, err = validate_avatar({"avatar_crown": "bare"})
+    def test_explicit_bare_hat_is_not_randomised(self):
+        # "bare" is a real token (bare-headed); it must be respected, not rerolled.
+        avatar, err = validate_avatar({"avatar_hat": "bare"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["crown"], "bare")
+        self.assertEqual(avatar["hat"], "bare")
 
     def test_invalid_token_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_crown": "sombrero"})
+        avatar, err = validate_avatar({"avatar_hat": "tophat"})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_crown", err)
+        self.assertIn("avatar_hat", err)
 
     def test_non_string_value_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_crown": 3})
+        avatar, err = validate_avatar({"avatar_hat": 3})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_crown", err)
+        self.assertIn("avatar_hat", err)
 
     def test_unrelated_params_are_ignored(self):
         body = {"nickname": "x", "avatar_weapon": "sword"}

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -31,39 +31,39 @@ class TestAvatarValidation(unittest.TestCase):
 
     def test_all_slots_provided_are_preserved(self):
         body = {
-            "avatar_base": "round",
-            "avatar_colour": "blue",
-            "avatar_eyes": "sunglasses",
-            "avatar_hat": "crown",
+            "avatar_spirit": "rusalka",
+            "avatar_colour": "river",
+            "avatar_eyes": "glowing",
+            "avatar_crown": "wreath",
         }
         avatar, err = validate_avatar(body)
         self.assertIsNone(err)
         self.assertEqual(
             avatar,
-            {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"},
+            {"spirit": "rusalka", "colour": "river", "eyes": "glowing", "crown": "wreath"},
         )
 
     def test_partial_input_preserves_given_and_fills_rest(self):
-        avatar, err = validate_avatar({"avatar_hat": "party"})
+        avatar, err = validate_avatar({"avatar_crown": "antlers"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["hat"], "party")
+        self.assertEqual(avatar["crown"], "antlers")
         self.assertTrue(_is_valid_avatar(avatar))
 
-    def test_explicit_none_hat_is_not_randomised(self):
-        # "none" is a real token (bare-headed); it must be respected, not rerolled.
-        avatar, err = validate_avatar({"avatar_hat": "none"})
+    def test_explicit_bare_crown_is_not_randomised(self):
+        # "bare" is a real token (no crown); it must be respected, not rerolled.
+        avatar, err = validate_avatar({"avatar_crown": "bare"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["hat"], "none")
+        self.assertEqual(avatar["crown"], "bare")
 
     def test_invalid_token_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_hat": "sombrero"})
+        avatar, err = validate_avatar({"avatar_crown": "sombrero"})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_hat", err)
+        self.assertIn("avatar_crown", err)
 
     def test_non_string_value_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_hat": 3})
+        avatar, err = validate_avatar({"avatar_crown": 3})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_hat", err)
+        self.assertIn("avatar_crown", err)
 
     def test_unrelated_params_are_ignored(self):
         body = {"nickname": "x", "avatar_weapon": "sword"}

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -44,9 +44,9 @@ class TestAvatarValidation(unittest.TestCase):
         )
 
     def test_partial_input_preserves_given_and_fills_rest(self):
-        avatar, err = validate_avatar({"avatar_hat": "antlers"})
+        avatar, err = validate_avatar({"avatar_hat": "kerchief"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["hat"], "antlers")
+        self.assertEqual(avatar["hat"], "kerchief")
         self.assertTrue(_is_valid_avatar(avatar))
 
     def test_explicit_bare_hat_is_not_randomised(self):

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -1,0 +1,76 @@
+# Unit tests for avatar vocabulary + validation (pure, no network / no AWS).
+import os
+import sys
+import unittest
+
+# Make the api/ dir importable so `shared.constants` resolves regardless of cwd.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.constants import AvatarSlots, random_avatar, validate_avatar
+
+SLOTS = set(AvatarSlots.OPTIONS)
+
+
+def _is_valid_avatar(avatar):
+    return (
+        isinstance(avatar, dict)
+        and set(avatar) == SLOTS
+        and all(avatar[slot] in AvatarSlots.OPTIONS[slot] for slot in SLOTS)
+    )
+
+
+class TestAvatarValidation(unittest.TestCase):
+
+    def test_random_avatar_is_valid(self):
+        self.assertTrue(_is_valid_avatar(random_avatar()))
+
+    def test_empty_body_fills_all_slots_randomly(self):
+        avatar, err = validate_avatar({})
+        self.assertIsNone(err)
+        self.assertTrue(_is_valid_avatar(avatar))
+
+    def test_all_slots_provided_are_preserved(self):
+        body = {
+            "avatar_base": "round",
+            "avatar_colour": "blue",
+            "avatar_eyes": "sunglasses",
+            "avatar_hat": "crown",
+        }
+        avatar, err = validate_avatar(body)
+        self.assertIsNone(err)
+        self.assertEqual(
+            avatar,
+            {"base": "round", "colour": "blue", "eyes": "sunglasses", "hat": "crown"},
+        )
+
+    def test_partial_input_preserves_given_and_fills_rest(self):
+        avatar, err = validate_avatar({"avatar_hat": "party"})
+        self.assertIsNone(err)
+        self.assertEqual(avatar["hat"], "party")
+        self.assertTrue(_is_valid_avatar(avatar))
+
+    def test_explicit_none_hat_is_not_randomised(self):
+        # "none" is a real token (bare-headed); it must be respected, not rerolled.
+        avatar, err = validate_avatar({"avatar_hat": "none"})
+        self.assertIsNone(err)
+        self.assertEqual(avatar["hat"], "none")
+
+    def test_invalid_token_is_rejected(self):
+        avatar, err = validate_avatar({"avatar_hat": "sombrero"})
+        self.assertIsNone(avatar)
+        self.assertIn("avatar_hat", err)
+
+    def test_non_string_value_is_rejected(self):
+        avatar, err = validate_avatar({"avatar_hat": 3})
+        self.assertIsNone(avatar)
+        self.assertIn("avatar_hat", err)
+
+    def test_unrelated_params_are_ignored(self):
+        body = {"nickname": "x", "avatar_weapon": "sword"}
+        avatar, err = validate_avatar(body)
+        self.assertIsNone(err)
+        self.assertTrue(_is_valid_avatar(avatar))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -30,44 +30,29 @@ class TestAvatarValidation(unittest.TestCase):
         self.assertTrue(_is_valid_avatar(avatar))
 
     def test_all_slots_provided_are_preserved(self):
-        body = {
-            "avatar_base": "wolf",
-            "avatar_cloth": "poppy",
-            "avatar_eyes": "narrow",
-            "avatar_hat": "wreath",
-        }
-        avatar, err = validate_avatar(body)
+        avatar, err = validate_avatar({"avatar_mask": "wolf", "avatar_material": "amber"})
         self.assertIsNone(err)
-        self.assertEqual(
-            avatar,
-            {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"},
-        )
+        self.assertEqual(avatar, {"mask": "wolf", "material": "amber"})
 
     def test_partial_input_preserves_given_and_fills_rest(self):
-        avatar, err = validate_avatar({"avatar_hat": "kerchief"})
+        # Only the material is supplied; the mask is randomly filled.
+        avatar, err = validate_avatar({"avatar_material": "gold"})
         self.assertIsNone(err)
-        self.assertEqual(avatar["hat"], "kerchief")
+        self.assertEqual(avatar["material"], "gold")
         self.assertTrue(_is_valid_avatar(avatar))
 
-    def test_explicit_bare_hat_is_not_randomised(self):
-        # "bare" is a real token (bare-headed); it must be respected, not rerolled.
-        avatar, err = validate_avatar({"avatar_hat": "bare"})
-        self.assertIsNone(err)
-        self.assertEqual(avatar["hat"], "bare")
-
     def test_invalid_token_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_hat": "tophat"})
+        avatar, err = validate_avatar({"avatar_material": "plastic"})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_hat", err)
+        self.assertIn("avatar_material", err)
 
     def test_non_string_value_is_rejected(self):
-        avatar, err = validate_avatar({"avatar_hat": 3})
+        avatar, err = validate_avatar({"avatar_mask": 3})
         self.assertIsNone(avatar)
-        self.assertIn("avatar_hat", err)
+        self.assertIn("avatar_mask", err)
 
     def test_unrelated_params_are_ignored(self):
-        body = {"nickname": "x", "avatar_weapon": "sword"}
-        avatar, err = validate_avatar(body)
+        avatar, err = validate_avatar({"nickname": "x", "avatar_charm": "bells"})
         self.assertIsNone(err)
         self.assertTrue(_is_valid_avatar(avatar))
 

--- a/api/test/test_avatar.py
+++ b/api/test/test_avatar.py
@@ -32,7 +32,7 @@ class TestAvatarValidation(unittest.TestCase):
     def test_all_slots_provided_are_preserved(self):
         body = {
             "avatar_base": "wolf",
-            "avatar_colour": "madder",
+            "avatar_cloth": "poppy",
             "avatar_eyes": "narrow",
             "avatar_hat": "wreath",
         }
@@ -40,7 +40,7 @@ class TestAvatarValidation(unittest.TestCase):
         self.assertIsNone(err)
         self.assertEqual(
             avatar,
-            {"base": "wolf", "colour": "madder", "eyes": "narrow", "hat": "wreath"},
+            {"base": "wolf", "cloth": "poppy", "eyes": "narrow", "hat": "wreath"},
         )
 
     def test_partial_input_preserves_given_and_fills_rest(self):


### PR DESCRIPTION
## Summary

Adds engine-side **player avatars** — a small, combinatorial cosmetic so human players can be visually distinct.

Each human player is a **Slavic ritual animal mask**, carved or cast in a **material** — two slots (8 masks × 6 materials = **48** combinations):

| Slot | Param | Tokens |
|---|---|---|
| **Mask** | `avatar_mask` | `tur` (aurochs) · `bear` · `goat` · `stork` · `wolf` · `raven` · `lynx` · `zubr` (European bison) |
| **Material** | `avatar_material` | `wood` · `stone` · `steel` · `gold` · `brass` · `amber` |

The engine is a thin **opaque carrier**: it validates each token against the vocabulary, stores the avatar on the player, and lets `censor_game` broadcast it like any other player field. It never renders or interprets the tokens — how an avatar looks is left entirely to the API consumer, which maps these tokens to its own art.

A few deliberate choices, recorded to prevent later mistakes:
- **No human face or skin** is depicted (it's a mask object), so no token implies a skin tone.
- **Material is a surface finish** (wood, stone, metal, resin), not a flat colour. Keeping appearance out of the engine leaves colour choices to the consumer and avoids tokens that could collide with separate colour-coded concepts such as team membership.
- **Tokens are kept distinct from the AI agent names** (see the invite-aiagent agent mapping), so a player avatar can't be confused with an agent.

## Transport & backward compatibility

The public endpoints are **HTTP GET**, with path/query params merged into the request body — a flat param can't carry a nested object. So avatars ride as flat **`avatar_mask` / `avatar_material`** params on the existing `ANY` routes: no POST, no API-Gateway change. Any caller that sends no `avatar_*` params (e.g. an older build) keeps working unchanged and gets a random valid avatar.

## Behaviour

- An omitted slot is randomly filled; omitting both yields a fully random avatar.
- An out-of-vocabulary token (e.g. `avatar_material=plastic`) returns **400**.
- **AI players are excluded** — they carry no `avatar` field.

## What changed

- `api/shared/constants.py` — `AvatarSlots` vocabulary + pure `random_avatar()` / `validate_avatar(body)`.
- `api/shared/game.py` — `create_player(game, nickname, avatar=None)` attaches `"avatar"`, defaulting to random.
- `api/join_game.py`, `api/create_game.py` — validate `avatar_*` params, pass to `create_player`.
- `api/test/test_avatar.py` — network-free unit tests (7).
- `api/README.md` — documents the slots, vocabulary, and stored shape.

No changes to `censor_game`, the DB/serialisation layer, the broadcast path, or AI handlers — all key-agnostic.

## Testing

```
cd api && python -m unittest test.test_avatar -v
```

## Deployment

The pipeline was validated earlier by a full parallel `deploy.sh` (22/22 functions, 0 failed) plus an end-to-end live test of all 15 HTTP routes against `api.blef.app`. The avatar design has since been simplified to this 2-slot mask+material model, so **a redeploy is needed for prod to match this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
