### PR TITLE
feat(retention): set a 365-day TTL on game creation (create_game.py)

### DIFF
--- a/api/create_game.py
+++ b/api/create_game.py
@@ -11,6 +11,14 @@ from shared.db import get_from_dynamodb, save_in_dynamodb, table
 from shared.game import create_player
 from shared.api_gateway import parse_event
 
+# Retention backstop: a game (and its per-round archives, which deep-copy the
+# game) carries this TTL from creation, so DynamoDB auto-expires the nicknames /
+# per-game IDs / match history ~this long after the game is created. The whole
+# record lives well under a day, so creation-anchored is effectively "from last
+# activity" and is the more conservative bound. Epoch seconds; set on the item,
+# so update_item handlers preserve it untouched.
+RETENTION_PERIOD_SECONDS = 365 * 24 * 60 * 60  # 365 days
+
 def register_rematch(prev_game, initiator_uuid, new_game_uuid):
     """
     Verifies the initiator was a player in the previous game and
@@ -98,7 +106,8 @@ def lambda_handler(event, context):
             "hands": [],
             "cp_nickname": None,
             "history": [],
-            "rules": rules_to_use
+            "rules": rules_to_use,
+            "ttl": int(time.time() + RETENTION_PERIOD_SECONDS)
         }
 
         nickname = body.get("nickname")


### PR DESCRIPTION
## What
Sets a `ttl` attribute (epoch seconds = creation + 365 days) on the game object at creation in `create_game.py`, so DynamoDB auto-expires the nicknames / per-game IDs / match history ~a year after creation — finite, GDPR-aligned retention instead of indefinite.

**Whole change is one file:** a `RETENTION_PERIOD_SECONDS` const + `"ttl": int(time.time() + RETENTION_PERIOD_SECONDS)` in the `game` dict.

## Why one line is enough
- **Every game** is created through this literal (fresh + rematch).
- **Per-round archives** `deepcopy` the game in `end_round`, carrying the `ttl`.
- **Update-only handlers** (`make_private`, `change_rules`, `play`, … — which write directly via `update_item` and bypass `db.py`) preserve unspecified attributes, so they never drop the `ttl`.

Creation-anchored (never refreshed) is the more conservative bound; games finish/abandon within a day, so it's effectively "from last activity". No backfill — only games created after this ships get a `ttl`.

## ⚠️ Required follow-up (privileged AWS creds)
This only *populates* the attribute. Enable TTL on it:
```
aws dynamodb update-time-to-live --table-name games \
  --time-to-live-specification "Enabled=true, AttributeName=ttl"
```
Do **not** point TTL at `last_modified` (past timestamps → deletes everything). TTL deletion is best-effort (within a few days of expiry), not instant.

## Testing
`moto` round-trip against the real (reverted) `db.py` + handlers: the creation literal stores `ttl`; an archive built via `deepcopy(game)` carries it; and `make_private` (which bypasses `db.py`) preserves it through an `update_item`. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)