### PR TITLE
Order same type AIs within team by nickname

### DIFF
--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -215,6 +215,21 @@ def seat_teams(team_counts):
             
     return final_table
 
+def order_same_type_ais(members):
+    """
+    Puts AIs of the same type in nickname order (so enumerated copies of an agent
+    appear in their natural order), keeping every other member's position unchanged.
+    """
+    indices_by_type = defaultdict(list)
+    for i, player in enumerate(members):
+        if player.get("ai_agent"):
+            indices_by_type[player["ai_agent"]].append(i)
+
+    for indices in indices_by_type.values():
+        ordered = sorted((members[i] for i in indices), key=lambda p: p["nickname"])
+        for i, player in zip(indices, ordered):
+            members[i] = player
+
 def arrange_players(players):
     # Shuffle players first so that within teams players are distributed randomly 
     shuffle(players)
@@ -231,6 +246,9 @@ def arrange_players(players):
                 players_by_team[-1].append(p) # Group all independent Humans into dummy team -1
         else:
             players_by_team[team].append(p)
+
+    for members in players_by_team.values():
+        order_same_type_ais(members)
             
     # Build the team_counts dictionary expected by the solver
     team_counts = {team_id: len(members) for team_id, members in players_by_team.items()}


### PR DESCRIPTION
Before teams, if there were AIs in the game, we sat humans as far apart from each other as possible. Within each AI type, we made the AI with the 'later' nickname (e.g. _Porevit 2 (AI)_ vs _Porevit (AI)_) appear later. 

After introducing teams, we focused on seating teams as far apart as possible, and then interspersing independent AIs with independent humans. However, if there are multiple AIs of the same type within one team or within the collection of independent AIs, we could still arrange them by nickname.

That's what the PR does. However, it uses the `ai_agent` field, which is problematic whenever multiple personalities are serviced by one agent, but doesn't rely on nickname patterns, which would be a bad pattern