### PR TITLE
Enable adding AIs straight into a team

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -69,7 +69,7 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat
 
 ## Invite AI agent
 
-Allows the game admin to add an AI player to the game before it starts.
+Allows the game admin to add an AI player to the game before it starts, optionally straight onto a team. If a team is given, the readiness of all human players is reset to `false`, as with a team change.
 
 * **URL**
 
@@ -88,20 +88,30 @@ Allows the game admin to add an AI player to the game before it starts.
   `"admin_uuid"=string`
   `"agent_name"=string`
 
+  **Optional:**
+
+  `"team"=integer` (1, 2, 3, or 4. Omit to make the AI independent)
+
 * **Success Response:**
 
   * **Code:** 200 OK <br />
   **Content:** `{"message":"alpha_1_(AI) joined the game"}`
 
-* **Sample Error Response:**
+* **Sample Error Responses:**
 
   * **Code:** 403 FORBIDDEN <br />
   **Content:** `{"error":"Game room full"}`
 
-* **Sample Call:**
+  * **Code:** 400 BAD REQUEST <br />
+  **Content:** `{"error":"Bad input value in 'team': 5\nTeam must be 1, 2, 3, 4, or null"}`
+
+* **Sample Calls:**
 
 ```
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/invite-aiagent?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&agent_name=alpha
+
+# Inviting an AI directly to Team 2
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/invite-aiagent?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&agent_name=alpha&team=2
 ```
 
 ## Remove AI agents

--- a/api/change_team.py
+++ b/api/change_team.py
@@ -4,6 +4,7 @@ from shared.response import response_payload, parameter_error_payload, error_pay
 from shared.db import table
 from shared.constants import GameStatus
 from shared.game import get_player_by_nickname, unset_human_readiness
+from shared.inputs import parse_team
 from shared.decorators import validate_game_request
 
 def update_in_dynamodb(game_uuid, players):
@@ -36,14 +37,10 @@ def lambda_handler(event, context, body, game):
         if not target_player:
             return parameter_error_payload("nickname", target_nickname, message="Target player not found in this game")
 
-        new_team = body.get("team")
-        if new_team is not None:
-            try:
-                new_team = int(new_team)
-            except (ValueError, TypeError):
-                return parameter_error_payload("team", new_team, message="Team must be an integer (1-4) or null")
-        if new_team not in [1, 2, 3, 4, None]:
-             return parameter_error_payload("team", new_team, message="Team must be 1, 2, 3, 4, or null")
+        try:
+            new_team = parse_team(body.get("team"))
+        except ValueError as err:
+            return parameter_error_payload("team", body.get("team"), message=str(err))
 
         # Admin can change anyone's team. Non-admins can only change their own.
         is_admin = (requester_nickname == game.get("admin_nickname"))

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -6,7 +6,8 @@ import decimal
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
 from shared.db import table
 from shared.constants import GameStatus
-from shared.game import calculate_actual_max_cards
+from shared.game import calculate_actual_max_cards, unset_human_readiness
+from shared.inputs import parse_team
 from shared.decorators import validate_game_request
 
 AGENT_MAPPING = json.loads(os.environ.get("agent_mapping"))
@@ -59,6 +60,11 @@ def lambda_handler(event, context, body, game):
         if not agent_type:
             return parameter_error_payload("agent_name", agent_name, message="Invalid agent_name")
 
+        try:
+            team = parse_team(body.get("team"))
+        except ValueError as err:
+            return parameter_error_payload("team", body.get("team"), message=str(err))
+
         nickname = set_nickname(agent_name, [p["nickname"] for p in players])
 
         player = {
@@ -67,9 +73,11 @@ def lambda_handler(event, context, body, game):
             "n_cards": 0,
             "ai_agent": agent_type,
             "ready": True,
-            "team": None
+            "team": team
         }
         players.append(player)
+        if team is not None:
+            players = unset_human_readiness(players)
 
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
         update_in_dynamodb(game["game_uuid"], players, max_cards)

--- a/api/shared/inputs.py
+++ b/api/shared/inputs.py
@@ -6,3 +6,18 @@ def is_valid_uuid(value):
         return True
     except ValueError:
         return False
+
+def parse_team(value):
+    """
+    Normalises a team parameter to an int (1-4), or None for an independent player.
+    Raises ValueError with a user-facing message for invalid values.
+    """
+    if value is None:
+        return None
+    try:
+        team = int(value)
+    except (ValueError, TypeError):
+        raise ValueError("Team must be an integer (1-4) or null")
+    if team not in [1, 2, 3, 4]:
+        raise ValueError("Team must be 1, 2, 3, 4, or null")
+    return team

--- a/api/test/test_inputs.py
+++ b/api/test/test_inputs.py
@@ -1,0 +1,37 @@
+# Unit tests for shared input parsing helpers.
+# No network / AWS needed. Run from the api/ directory:
+#   python -m unittest test.test_inputs
+# or directly:
+#   python test/test_inputs.py
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from shared.inputs import parse_team  # noqa: E402
+
+
+class TestParseTeam(unittest.TestCase):
+
+    def test_none_means_independent(self):
+        self.assertIsNone(parse_team(None))
+
+    def test_valid_teams(self):
+        for value in [1, 2, 3, 4, "1", "4"]:
+            self.assertEqual(parse_team(value), int(value))
+
+    def test_out_of_range(self):
+        for value in [0, 5, -1, "7"]:
+            with self.assertRaises(ValueError) as ctx:
+                parse_team(value)
+            self.assertEqual(str(ctx.exception), "Team must be 1, 2, 3, 4, or null")
+
+    def test_not_an_integer(self):
+        for value in ["green", "", [2]]:
+            with self.assertRaises(ValueError) as ctx:
+                parse_team(value)
+            self.assertEqual(str(ctx.exception), "Team must be an integer (1-4) or null")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Enable adding AIs to a team in one API call, rather than having to `invite-aiagent` first and `change-team` second