### PR TITLE
Add an endpoint for reporting nicknames

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -656,6 +656,54 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-team?player_uuid=f
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-team?player_uuid=f828f87f-4c64-4ba8-b9e2-3a7760910a20&nickname=alpha_(AI)
 ```
 
+## Report nickname
+
+Allows anyone, including observers, to report an objectionable nickname in a game. Invisible to other users.
+
+* **URL**
+
+  /games/{game_uuid}/report-nickname
+
+* **URL Params**
+
+  **Required:**
+
+  `"game_uuid"=string`
+
+* **Data Params**
+
+  **Required:**
+
+  `"nickname"=string` (The nickname being reported)
+
+  **Optional:**
+
+  `"player_uuid"=string` (The reporter's own player UUID if applicable)
+  `"comment"=string` (Free-text context, max 500 characters)
+
+* **Success Response:**
+
+  * **Code:** 200 OK <br />
+  **Content:** `{"message":"Report received"}`
+
+* **Sample Error Responses:**
+
+  * **Code:** 400 BAD REQUEST <br />
+  **Content:** `{"error":"Bad input value in 'nickname': ghost\nReported nickname not found in this game"}`
+
+  * **Code:** 400 BAD REQUEST <br />
+  **Content:** `{"error":"Bad input value in 'comment': 512 characters\nComment too long (max 500 characters)"}`
+
+* **Sample Calls:**
+
+```bash
+# An observer reporting a nickname
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/report-nickname?nickname=coolcat
+
+# A player reporting a nickname with a comment
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/report-nickname?player_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&nickname=coolcat&comment=impersonation
+```
+
 # Action IDs
 
 Action IDs depend on the `deck_size` rule.

--- a/api/report_nickname.py
+++ b/api/report_nickname.py
@@ -1,0 +1,66 @@
+import time
+import unicodedata
+from shared.response import response_payload, parameter_error_payload, internal_error_payload
+from shared.db import reports_table
+from shared.game import get_player_by_nickname, get_nickname_by_uuid
+from shared.inputs import is_valid_uuid
+from shared.decorators import validate_game_request
+
+# Retention period enforced by DynamoDB TTL on the reports table
+REPORT_RETENTION_PERIOD_SECONDS = 180 * 24 * 60 * 60  # 180 days
+MAX_COMMENT_LENGTH = 500
+
+
+@validate_game_request()
+def lambda_handler(event, context, body, game):
+    try:
+        players = game.get("players", [])
+
+        reported = body.get("nickname")
+        if not reported:
+            return parameter_error_payload("nickname", reported, message="Reported nickname missing - please supply it")
+        # NFC-normalise before matching: stored nicknames are NFC
+        reported = unicodedata.normalize("NFC", str(reported))
+        if not get_player_by_nickname(players, reported):
+            return parameter_error_payload("nickname", reported, message="Reported nickname not found in this game")
+
+        # Reporting is open to observers, so the reporter identity is optional, but when supplied, it must belong to a player of this game
+        reporter_uuid = body.get("player_uuid")
+        reporter_nickname = None
+        if reporter_uuid is not None:
+            reporter_uuid = str(reporter_uuid)
+            if not is_valid_uuid(reporter_uuid):
+                return parameter_error_payload("player_uuid", reporter_uuid, message="Invalid player UUID")
+            reporter_nickname = get_nickname_by_uuid(players, reporter_uuid)
+            if not reporter_nickname:
+                return parameter_error_payload("player_uuid", reporter_uuid, message="The UUID does not match any player in this game")
+
+        comment = body.get("comment")
+        if comment is not None:
+            if not isinstance(comment, str):
+                return parameter_error_payload("comment", comment, message="Comment must be a string")
+            if len(comment) > MAX_COMMENT_LENGTH:
+                return parameter_error_payload("comment", f"{len(comment)} characters", message=f"Comment too long (max {MAX_COMMENT_LENGTH} characters)")
+            comment = comment or None
+
+        now = int(time.time())
+        report = {
+            "game_uuid": game["game_uuid"],
+            # The key collapses repeat reports (same reporter, same nickname, same game) into a single item
+            "report_id": f"{reported}#{reporter_uuid or 'observer'}",
+            "reported_nickname": reported,
+            "created": now,
+            "ttl": now + REPORT_RETENTION_PERIOD_SECONDS
+        }
+        if reporter_uuid:
+            report["reporter_uuid"] = reporter_uuid
+            report["reporter_nickname"] = reporter_nickname
+        if comment:
+            report["comment"] = comment
+
+        reports_table.put_item(Item=report)
+
+        return response_payload(200, {"message": "Report received"})
+
+    except Exception as err:
+        return internal_error_payload(err)

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -8,6 +8,7 @@ from .logging import logger
 dynamodb = boto3.resource('dynamodb')
 table = dynamodb.Table("games")
 websocket_table = dynamodb.Table("watch_game_websocket_manager")
+reports_table = dynamodb.Table("nickname_reports")
 
 def get_from_dynamodb(game_uuid):
     response = table.query(KeyConditionExpression=Key('game_uuid').eq(game_uuid))

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -28,7 +28,7 @@ immediately, with no integration changes required.
 
 | API | Functions |
 |-----|-----------|
-| HTTP API (`blef-game-engine-http-api`) | `blef-create-game`, `blef-get-game`, `blef-join-game`, `blef-play`, `blef-start-game`, `blef-set-readiness`, `blef-change-rules`, `blef-change-team`, `blef-make-public`, `blef-make-private`, `blef-remove-player`, `blef-remove-ais`, `blef-send-reaction`, `blef-list-public-games`, `blef-invite-aiagent` |
+| HTTP API (`blef-game-engine-http-api`) | `blef-create-game`, `blef-get-game`, `blef-join-game`, `blef-play`, `blef-start-game`, `blef-set-readiness`, `blef-change-rules`, `blef-change-team`, `blef-make-public`, `blef-make-private`, `blef-remove-player`, `blef-remove-ais`, `blef-send-reaction`, `blef-list-public-games`, `blef-invite-aiagent`, `blef-report-nickname` |
 | WebSocket API (`blef-watch-game-websocket-api`) | `blef-watch-game-connect`, `blef-watch-game-disconnect` |
 
 All other Lambdas (DynamoDB-stream, SQS, and cron-triggered handlers such as
@@ -44,6 +44,30 @@ concurrently through a bounded, throttle-safe worker pool (see the script header
 > Note: the HTTP API stage (`$default`) has auto-deploy enabled. The WebSocket API stage
 > (`production`) does **not** auto-deploy — if you ever change a WebSocket integration or
 > route, run `aws apigatewayv2 create-deployment --api-id <ws-api-id> --stage-name production`.
+
+### Nickname reports infrastructure (one-time setup)
+
+`blef-report-nickname` needs resources that `deploy.sh` does not create:
+
+1. **DynamoDB table `nickname_reports`** — partition key `game_uuid` (S), sort key
+   `report_id` (S), TTL enabled on attribute `ttl` (reports self-expire after 180 days):
+
+   ```bash
+   aws dynamodb create-table --table-name nickname_reports \
+     --attribute-definitions AttributeName=game_uuid,AttributeType=S AttributeName=report_id,AttributeType=S \
+     --key-schema AttributeName=game_uuid,KeyType=HASH AttributeName=report_id,KeyType=RANGE \
+     --billing-mode PAY_PER_REQUEST
+   aws dynamodb update-time-to-live --table-name nickname_reports \
+     --time-to-live-specification "Enabled=true, AttributeName=ttl"
+   ```
+
+2. **The Lambda function and API Gateway route** — create `blef-report-nickname`
+   like the other HTTP API functions (same runtime/role pattern; its role also needs
+   `dynamodb:PutItem` on `nickname_reports`), then add the route
+   `GET /games/{game_uuid}/report-nickname` targeting it. `deploy.sh` only
+   updates code on existing functions.
+
+Reports are reviewed by the maintainers pulling straight from DynamoDB. `deployment/fetch_reports.py` scans the table, prints reports that arrived since its last run, and flags reported nicknames that pass the current profanity filter (blocklist candidates).
 
 
 ### Architecture overview

--- a/deployment/fetch_reports.py
+++ b/deployment/fetch_reports.py
@@ -1,0 +1,95 @@
+# Maintainer tool: pulls nickname reports from the nickname_reports DynamoDB
+# table and prints the ones that arrived since the last run, flagging whether
+# each reported nickname is already caught by the profanity filter - the ones
+# that pass it are candidates for blocklist additions. The newest report time
+# already seen is kept in ~/.blef_reports_state so scheduled runs only surface
+# new reports.
+#
+# Run from any machine with AWS credentials for the account (needs
+# dynamodb:Scan on nickname_reports):
+#   python deployment/fetch_reports.py          # new reports since last run
+#   python deployment/fetch_reports.py --all    # full table, state untouched
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "api"))
+from shared.profanity_filter import is_offensive  # noqa: E402
+
+STATE_FILE = Path.home() / ".blef_reports_state"
+
+
+def load_last_seen():
+    try:
+        return int(json.loads(STATE_FILE.read_text())["last_created"])
+    except (OSError, ValueError, KeyError):
+        return 0
+
+
+def save_last_seen(timestamp):
+    STATE_FILE.write_text(json.dumps({"last_created": int(timestamp)}))
+
+
+def fetch_reports(table):
+    items = []
+    kwargs = {}
+    while True:
+        page = table.scan(**kwargs)
+        items.extend(page.get("Items", []))
+        if "LastEvaluatedKey" not in page:
+            return items
+        kwargs["ExclusiveStartKey"] = page["LastEvaluatedKey"]
+
+
+def format_report(report):
+    when = datetime.fromtimestamp(int(report["created"]), tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    reporter = report.get("reporter_nickname", "observer")
+    caught = "caught by filter" if is_offensive(report["reported_nickname"]) else "PASSES filter"
+    line = f'[{when}] "{report["reported_nickname"]}" ({caught}) reported by {reporter} in game {report["game_uuid"]}'
+    if report.get("comment"):
+        line += f'\n    comment: {report["comment"]}'
+    return line
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch and triage nickname reports")
+    parser.add_argument("--all", action="store_true", help="show the full table and leave the last-seen state untouched")
+    args = parser.parse_args()
+
+    table = boto3.resource("dynamodb").Table("nickname_reports")
+    reports = fetch_reports(table)
+
+    last_seen = 0 if args.all else load_last_seen()
+    new = sorted((r for r in reports if int(r["created"]) > last_seen), key=lambda r: int(r["created"]))
+    if not new:
+        print("No new reports.")
+        return
+
+    print(f"{len(new)} report(s):")
+    for report in new:
+        print(format_report(report))
+
+    # Distinct rows per (game, nickname) = distinct reporters, since repeat
+    # reports by the same reporter overwrite (see report_nickname.py).
+    counts = Counter((r["game_uuid"], r["reported_nickname"]) for r in new)
+    multi = {k: c for k, c in counts.items() if c > 1}
+    if multi:
+        print("\nReported by multiple parties:")
+        for (game_uuid, nickname), count in sorted(multi.items(), key=lambda kv: -kv[1]):
+            print(f'  "{nickname}" in game {game_uuid}: {count} reporters')
+
+    missed = sorted({r["reported_nickname"] for r in new if not is_offensive(r["reported_nickname"])})
+    if missed:
+        print(f"\nPassing the current profanity filter (blocklist candidates): {', '.join(missed)}")
+
+    if not args.all:
+        save_last_seen(max(int(r["created"]) for r in new))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allows anyone, including observers, to report any nickname in a game. 

Needs a new DynamoDB table as described in the README, with fields `game_uuid`, `report_id`, `reported_nickname`, `created`, `ttl`.

Chosen over a `mailto` mechanism as the latter is not in-app and might be broken if there's no email client configured on the user's phone.

Reports are stored for 180 days and there is no review mechanism included within the engine, but instead there is a `fetch_reports.py` suggested as a script to run periodically