### PR TITLE
Add an initial_cards rule

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -246,6 +246,12 @@ Allows the game admin to change the rules of the game before it starts. This inc
   * `"jokers"=integer` (0–12)
   * `"blanks"=integer` (0–12)
   * `"max_cards"=integer` (0 for no preference, or 1–11)
+  * `"initial_cards"` — how many cards each player opens with. One of:
+    * `integer` — every player opens with that many (0 unsets the rule)
+    * `"random"` — each player opens with a random number of cards
+    * `"nickname:count,nickname:count"` — named players open with the given
+      counts and the rest open with 1. Allows handicaps and challenges
+      (e.g. `You:10,Morana_(AI):2`)
 
 * **Success Response:**
 
@@ -267,6 +273,9 @@ Allows the game admin to change the rules of the game before it starts. This inc
   * Rules can only be changed before the game starts (status = `"Not started"`)  
   * When `time_limit` is non-zero after any rule changes from the current request have been applied, all human players' readiness is reset to `false`  
   * The `max_cards_preference` value in rules is retained, but the `max_cards` in the game state may differ if the preference isn't feasible for the current player count  
+  * `initial_cards` counts must be between 1 and the game's `max_cards`, and any nickname given must already be in the game. Both are checked **after** all rules in the request are applied, so the result does not depend on parameter order  
+  * `initial_cards` is a rule like any other, so a rematch **inherits** it. Counts are clamped to the new game's `max_cards` and players the rule does not name open with 1, so an inherited rule adapts to a changed roster instead of failing. Pass `initial_cards=0` to clear it  
+  * Uneven openings are visible to everyone in the `rules` field of the game state before the game starts  
 
 * **Sample Calls:**
 
@@ -276,6 +285,18 @@ curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f
 
 # Change multiple rules
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&time_limit=15&common_cards=4&deck_size=32
+
+# Everyone opens with 2 cards
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&initial_cards=2
+
+# Random opening hands
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&initial_cards=random
+
+# A challenge: beat Morana starting with 10 cards while she has 2
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&initial_cards=MyAdmin:10,Morana_(AI):2
+
+# Clear it
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/change-rules?admin_uuid=f65e08df-d82a-46b1-979b-550cbc04d56d&initial_cards=0
 ```
 
 

--- a/api/README.md
+++ b/api/README.md
@@ -273,7 +273,9 @@ Allows the game admin to change the rules of the game before it starts. This inc
   * Rules can only be changed before the game starts (status = `"Not started"`)  
   * When `time_limit` is non-zero after any rule changes from the current request have been applied, all human players' readiness is reset to `false`  
   * The `max_cards_preference` value in rules is retained, but the `max_cards` in the game state may differ if the preference isn't feasible for the current player count  
-  * `initial_cards` counts must be between 1 and the game's `max_cards`, and any nickname given must already be in the game. Both are checked **after** all rules in the request are applied, so the result does not depend on parameter order  
+  * `initial_cards` counts must be between 1 and the game's `max_cards`, and any nickname given must already be in the game. Both are checked **after** all rules in the request are applied, so the result does not depend on parameter order. Nicknames are matched in their stored (NFC-normalised) form  
+  * These checks run **only when the request sets `initial_cards`**. A rule that was valid when set can go stale — a named player leaves, or the roster grows and `max_cards` falls below the count — and a stale rule must never block unrelated rule changes. It adapts at game start instead (see below)  
+  * When a request sets `initial_cards`, all human players' readiness is reset to `false`, as with a team change, because uneven openings change the fairness players agreed to. This happens regardless of `time_limit`  
   * `initial_cards` is a rule like any other, so a rematch **inherits** it. Counts are clamped to the new game's `max_cards` and players the rule does not name open with 1, so an inherited rule adapts to a changed roster instead of failing. Pass `initial_cards=0` to clear it  
   * Uneven openings are visible to everyone in the `rules` field of the game state before the game starts  
 

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -94,13 +94,17 @@ def lambda_handler(event, context, body, game):
 
         max_cards = calculate_actual_max_cards(rules, len(players))
 
-        # After the loop, so the check sees the settled deck size and player
-        # count rather than whatever order the parameters happened to arrive in.
-        if "initial_cards" in rules:
+        # Checked after the loop so it sees the settled deck size and player
+        # count, not the parameter order — but only when this request sets it. A
+        # stale rule (a named player left, or the roster grew and max_cards fell)
+        # must not block unrelated rule changes; start_game clamps and defaults.
+        if "initial_cards" in body:
             error = RuleValues.validate_initial_cards_rule(
-                rules["initial_cards"], [p["nickname"] for p in players], max_cards)
+                rules.get("initial_cards"), [p["nickname"] for p in players], max_cards)
             if error:
-                return parameter_error_payload("initial_cards", body.get("initial_cards"), error)
+                return parameter_error_payload("initial_cards", body["initial_cards"], error)
+            # Uneven openings change the agreed fairness, so re-ask — as change_team does.
+            players = unset_human_readiness(players)
 
         logger.info(f'## NEW RULES: {rules}')
         logger.info(f'## MAX CARDS: {max_cards}')

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -80,11 +80,27 @@ def lambda_handler(event, context, body, game):
                         f"Max cards must be {RuleValues.MAX_CARDS_NO_PREFERENCE_API} (for no preference) or an integer between "
                         f"{RuleValues.MAX_CARDS_FIXED_RANGE.BOTTOM} and {RuleValues.MAX_CARDS_FIXED_RANGE.TOP}")
                 rules["max_cards_preference"] = value if value != RuleValues.MAX_CARDS_NO_PREFERENCE_API else RuleValues.MAX_CARDS_NO_PREFERENCE_INTERNAL
+            elif key == "initial_cards":
+                declaration, error = RuleValues.parse_initial_cards_rule(value)
+                if error:
+                    return parameter_error_payload(key, value, error)
+                if declaration is None:
+                    rules.pop(key, None)
+                else:
+                    rules[key] = declaration
 
         if rules.get("time_limit", RuleValues.TIME_LIMIT_NO_LIMIT) != RuleValues.TIME_LIMIT_NO_LIMIT:
             players = unset_human_readiness(players)
 
         max_cards = calculate_actual_max_cards(rules, len(players))
+
+        # After the loop, so the check sees the settled deck size and player
+        # count rather than whatever order the parameters happened to arrive in.
+        if "initial_cards" in rules:
+            error = RuleValues.validate_initial_cards_rule(
+                rules["initial_cards"], [p["nickname"] for p in players], max_cards)
+            if error:
+                return parameter_error_payload("initial_cards", body.get("initial_cards"), error)
 
         logger.info(f'## NEW RULES: {rules}')
         logger.info(f'## MAX CARDS: {max_cards}')

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -47,7 +47,14 @@ class RuleValues:
 
     COMMON_CARDS_FIXED_RANGE = _Range(0, 12) # We don't envisage players needing more than 12
     COMMON_CARDS_DEFAULT = 0
-    
+
+    # Opening hand sizes. Default is one card each; the rule can set a shared
+    # count, randomise per player, or name players individually (handicaps and
+    # challenges). 0 unsets it, mirroring MAX_CARDS_NO_PREFERENCE_API.
+    INITIAL_CARDS_UNSET = 0
+    INITIAL_CARDS_RANDOM = "random"
+    INITIAL_CARDS_DEFAULT = 1
+
     @classmethod
     def is_valid_time_limit_rule(cls, value):
         """Checks if a value is a valid time limit rule."""
@@ -62,6 +69,42 @@ class RuleValues:
     def is_valid_max_cards_rule(cls, value):
         """Checks if a value is a valid max cards preference."""
         return (value == cls.MAX_CARDS_NO_PREFERENCE_API) or (cls.MAX_CARDS_FIXED_RANGE.BOTTOM <= value <= cls.MAX_CARDS_FIXED_RANGE.TOP)
+
+    @classmethod
+    def parse_initial_cards_rule(cls, raw):
+        """Parse an initial_cards declaration into an int, "random", a
+        nickname->count dict, or None to unset. Returns (value, error)."""
+        text = str(raw).strip()
+        if text in ("", str(cls.INITIAL_CARDS_UNSET)):
+            return None, None
+        if text.lower() == cls.INITIAL_CARDS_RANDOM:
+            return cls.INITIAL_CARDS_RANDOM, None
+        if text.isdigit():
+            return int(text), None
+        mapping = {}
+        for entry in text.split(","):
+            nickname, _, count = entry.rpartition(":")
+            if not nickname or not count.isdigit():
+                return None, "Expected an integer, 'random', or nickname:count pairs"
+            mapping[nickname] = int(count)
+        return mapping, None
+
+    @classmethod
+    def validate_initial_cards_rule(cls, value, nicknames, max_cards):
+        """Feasibility and roster check, returning an error message or None. Run
+        AFTER every rule is settled: max_cards depends on deck size and player
+        count, so validating mid-request would depend on parameter order."""
+        if value is None or value == cls.INITIAL_CARDS_RANDOM:
+            return None
+        counts = list(value.values()) if isinstance(value, dict) else [value]
+        if not all(cls.MAX_CARDS_FIXED_RANGE.BOTTOM <= c <= int(max_cards) for c in counts):
+            return f"Initial cards must be between {cls.MAX_CARDS_FIXED_RANGE.BOTTOM} and {max_cards}"
+        if isinstance(value, dict):
+            unknown = sorted(set(value) - set(nicknames))
+            if unknown:
+                return f"Target player not found in this game: {unknown[0]}"
+        return None
+
 
 class SpecialNicknames:
     COMMON_HAND = "0"

--- a/api/shared/constants.py
+++ b/api/shared/constants.py
@@ -1,4 +1,5 @@
 import random
+import unicodedata
 from enum import Enum
 
 class GameStatus:
@@ -86,7 +87,10 @@ class RuleValues:
             nickname, _, count = entry.rpartition(":")
             if not nickname or not count.isdigit():
                 return None, "Expected an integer, 'random', or nickname:count pairs"
-            mapping[nickname] = int(count)
+            # NFC to match how parse_nickname stores rosters, so a decomposed
+            # accent still resolves. Not parse_nickname itself: AI nicknames
+            # ("Perun_(AI)") are engine-made and fail its format rule.
+            mapping[unicodedata.normalize("NFC", nickname.strip())] = int(count)
         return mapping, None
 
     @classmethod

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -331,13 +331,39 @@ def calculate_actual_max_cards(rules, n_players):
         suggested_total_cards_in_round = calculate_suggested_max_cards_dealt_in_any_round(rules)
         return calculate_largest_feasible_max_cards_per_player(n_players, suggested_total_cards_in_round, common_cards_rule)
 
+def resolve_opening_hands(players, rules, max_cards):
+    """Cards each player opens with. One each unless `initial_cards` sets a
+    shared count, randomises, or names players individually.
+
+    Counts are clamped rather than refused here: change_rules already rejected
+    bad values, and the roster can grow afterwards (shrinking max_cards), which
+    must not make a game unstartable. Players the rule does not name open with
+    the default, so an inherited rule degrades instead of failing.
+    """
+    rule = rules.get("initial_cards")
+    limit = max(RuleValues.INITIAL_CARDS_DEFAULT, int(max_cards))
+
+    def bounded(count):
+        return max(RuleValues.INITIAL_CARDS_DEFAULT, min(int(count), limit))
+
+    if rule == RuleValues.INITIAL_CARDS_RANDOM:
+        return {p["nickname"]: randint(RuleValues.INITIAL_CARDS_DEFAULT, limit) for p in players}
+    if isinstance(rule, dict):
+        return {p["nickname"]: bounded(rule.get(p["nickname"], RuleValues.INITIAL_CARDS_DEFAULT))
+                for p in players}
+    if rule:
+        return {p["nickname"]: bounded(rule) for p in players}
+    return {p["nickname"]: RuleValues.INITIAL_CARDS_DEFAULT for p in players}
+
+
 def start_game(game):
     game_uuid = game["game_uuid"]
     players = game["players"]
     rules = game.get("rules", {})
 
+    opening_hands = resolve_opening_hands(players, rules, game.get("max_cards", 0))
     for player in players:
-        player["n_cards"] = 1
+        player["n_cards"] = opening_hands[player["nickname"]]
 
     public = "false"
     status = GameStatus.RUNNING

--- a/api/test/test_inputs.py
+++ b/api/test/test_inputs.py
@@ -5,10 +5,12 @@
 #   python test/test_inputs.py
 import os
 import sys
+import unicodedata
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from shared.inputs import parse_team  # noqa: E402
+from shared.constants import RuleValues  # noqa: E402
 
 
 class TestParseTeam(unittest.TestCase):
@@ -31,6 +33,54 @@ class TestParseTeam(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 parse_team(value)
             self.assertEqual(str(ctx.exception), "Team must be an integer (1-4) or null")
+
+
+class TestInitialCardsRule(unittest.TestCase):
+
+    def parse(self, raw):
+        value, error = RuleValues.parse_initial_cards_rule(raw)
+        self.assertIsNone(error, error)
+        return value
+
+    def test_unset(self):
+        for raw in [0, "0", "", "  "]:
+            self.assertIsNone(self.parse(raw))
+
+    def test_shared_count_and_random(self):
+        self.assertEqual(self.parse("3"), 3)
+        self.assertEqual(self.parse("Random"), RuleValues.INITIAL_CARDS_RANDOM)
+
+    def test_named_players(self):
+        self.assertEqual(self.parse("Ann:2,Bob_(AI):5"), {"Ann": 2, "Bob_(AI)": 5})
+
+    def test_unparseable(self):
+        for raw in ["garbage", "Ann:", "Ann:two", ":3"]:
+            _, error = RuleValues.parse_initial_cards_rule(raw)
+            self.assertIsNotNone(error, raw)
+
+    def test_decomposed_accent_matches_the_stored_roster(self):
+        """Rosters are stored NFC (parse_nickname normalises on join), so a
+        decomposed accent must resolve to the same player rather than be
+        rejected as absent — and must key the dict in the roster's form."""
+        nfd = unicodedata.normalize("NFD", "Café")
+        self.assertNotEqual(nfd, "Café")
+        rule = self.parse(f"{nfd}:3")
+        self.assertEqual(rule, {"Café": 3})
+        self.assertIsNone(RuleValues.validate_initial_cards_rule(rule, ["Café"], 5))
+
+    def test_unknown_nickname_is_rejected(self):
+        rule = self.parse("Ghost:2")
+        error = RuleValues.validate_initial_cards_rule(rule, ["Ann"], 5)
+        self.assertIn("Target player not found", error)
+
+    def test_counts_must_fit_max_cards(self):
+        for rule in [self.parse("9"), self.parse("Ann:9"), self.parse("Ann:0")]:
+            self.assertIn("Initial cards must be between",
+                          RuleValues.validate_initial_cards_rule(rule, ["Ann"], 5))
+
+    def test_unset_and_random_skip_validation(self):
+        for rule in [None, RuleValues.INITIAL_CARDS_RANDOM]:
+            self.assertIsNone(RuleValues.validate_initial_cards_rule(rule, [], 5))
 
 
 if __name__ == "__main__":

--- a/api/test/test_validation.py
+++ b/api/test/test_validation.py
@@ -165,6 +165,57 @@ class TestAPIValidation(unittest.TestCase):
         self.assertEqual(forward.status_code, backward.status_code,
                          "initial_cards validation depends on parameter order")
 
+    def test_handler_change_rules_stale_initial_cards_does_not_block_other_rules(self):
+        """A rule that was valid when set can go stale as the roster moves. It
+        must never lock the game's other rules: only a request that actually
+        sets initial_cards is validated, and start_game clamps the rest."""
+        url = f"{BASE_URL}/games/{self.game_uuid}/change-rules"
+        join_url = f"{BASE_URL}/games/{self.game_uuid}/join"
+
+        # A named player leaves. Cara keeps the game at two seats, so it is the
+        # roster check that would fire rather than max_cards collapsing to 0.
+        bob_uuid = self.session.get(join_url, params={"nickname": "Bob"}).json()["player_uuid"]
+        self.session.get(join_url, params={"nickname": "Cara"})
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                             "initial_cards": "Bob:3"})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.session.get(f"{BASE_URL}/games/{self.game_uuid}/remove-player",
+                         params={"player_uuid": bob_uuid, "nickname": "Bob"})
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "deck_size": 32})
+        self.assertEqual(resp.status_code, 200,
+                         f"a departed player's seed blocked an unrelated rule change: {resp.text}")
+
+        # The roster grows, so max_cards falls below a count that was feasible.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                             "deck_size": 24, "initial_cards": 8})
+        self.assertEqual(resp.status_code, 200, resp.text)  # 2 seats on 24 cards allows 11
+        for nickname in ["Dana", "Efim", "Fola", "Gita"]:      # 5+ seats allows only 4
+            self.session.get(join_url, params={"nickname": nickname})
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "deck_size": 32})
+        self.assertEqual(resp.status_code, 200,
+                         f"an over-max seed blocked an unrelated rule change: {resp.text}")
+
+    def test_handler_change_rules_initial_cards_unsets_readiness(self):
+        """Changing the opening hands changes the fairness players agreed to, so
+        it must re-ask for readiness — the treatment team changes already get."""
+        url = f"{BASE_URL}/games/{self.game_uuid}/change-rules"
+        self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Bob"})
+
+        # Only the admin declares ready, or the game would start on the spot.
+        resp = self.session.get(f"{BASE_URL}/games/{self.game_uuid}/set-readiness",
+                                params={"player_uuid": self.admin_uuid, "ready": "True"})
+        self.assertEqual(resp.status_code, 200, resp.text)
+
+        def admin_is_ready():
+            players = self.session.get(f"{BASE_URL}/games/{self.game_uuid}",
+                                       params={"player_uuid": self.admin_uuid}).json()["players"]
+            return next(p for p in players if p["nickname"] == "AdminUser").get("ready")
+
+        self.assertTrue(admin_is_ready(), "setup failed: readiness never took")
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": 2})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertFalse(admin_is_ready(), "initial_cards changed without re-asking for readiness")
+
     def test_handler_invite_aiagent(self):
         """Tests the simplified invite-aiagent handler logic."""
         url = f"{BASE_URL}/games/{self.game_uuid}/invite-aiagent"

--- a/api/test/test_validation.py
+++ b/api/test/test_validation.py
@@ -106,6 +106,65 @@ class TestAPIValidation(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Every rule must be an integer", resp.json().get("error", ""))
 
+    def test_handler_change_rules_initial_cards(self):
+        """Tests the initial_cards rule: its three forms, unset, and validation."""
+        url = f"{BASE_URL}/games/{self.game_uuid}/change-rules"
+        state_url = f"{BASE_URL}/games/{self.game_uuid}"
+
+        def rules():
+            return self.session.get(state_url, params={"player_uuid": self.admin_uuid}).json()["rules"]
+
+        # A shared count applies to everyone.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": 2})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(rules()["initial_cards"]), 2)
+
+        # "random" is stored as-is and resolved per player at start.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": "random"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(rules()["initial_cards"], "random")
+
+        # Named players — the handicap / challenge form.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                             "initial_cards": "AdminUser:3"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(int(rules()["initial_cards"]["AdminUser"]), 3)
+
+        # 0 clears it.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": 0})
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("initial_cards", rules())
+
+        # Nicknames must already be in the game.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                             "initial_cards": "NoSuchPlayer:2"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Target player not found", resp.json().get("error", ""))
+
+        # Unparseable declarations are rejected.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": "garbage"})
+        self.assertEqual(resp.status_code, 400)
+
+        # Counts above max_cards are refused, not clamped.
+        resp = self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": 99})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Initial cards must be between", resp.json().get("error", ""))
+
+    def test_handler_change_rules_initial_cards_is_order_independent(self):
+        """The feasibility check must see the settled rules, not whatever order
+        the parameters arrived in. A 24-card deck allows fewer cards per player
+        than a 32-card one, so the same pair of rules must give the same answer
+        both ways round."""
+        url = f"{BASE_URL}/games/{self.game_uuid}/change-rules"
+
+        forward = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                                "deck_size": 24, "initial_cards": 11})
+        self.session.get(url, params={"admin_uuid": self.admin_uuid, "initial_cards": 0})
+        backward = self.session.get(url, params={"admin_uuid": self.admin_uuid,
+                                                 "initial_cards": 11, "deck_size": 24})
+        self.assertEqual(forward.status_code, backward.status_code,
+                         "initial_cards validation depends on parameter order")
+
     def test_handler_invite_aiagent(self):
         """Tests the simplified invite-aiagent handler logic."""
         url = f"{BASE_URL}/games/{self.game_uuid}/invite-aiagent"


### PR DESCRIPTION
Games could only ever open with one card each. This adds a rule for the opening hand sizes.

## The rule

`initial_cards`, on change-rules, in three forms:

| value | meaning |
|---|---|
| `integer` | every player opens with that many |
| `"random"` | each player opens with a random hand |
| `"nickname:count,…"` | named players open with those counts, the rest with 1 |
| `0` | unsets the rule (mirrors `max_cards`) |

The named form is what makes handicaps and challenges expressible — *"beat Morana starting on 10 while she has 2"*, or giving a stronger friend fewer cards.

**Why a rule and not a start-endpoint parameter:** a timed game never calls the start endpoint — `set_readiness` auto-starts it once everyone is ready. Rules are on the game whichever path runs, so `start_game.py` and `set_readiness.py` are untouched by this diff.

`draw_cards` already deals `player["n_cards"]` per player, so it follows whatever the opening resolves to.

## Addressing the review

**Order-dependent validation.** Fixed properly: parsing happens in the parameter loop, but the feasibility and roster check runs *after* the whole request is applied, against settled rules. `test_handler_change_rules_initial_cards_is_order_independent` asserts both orderings of `deck_size` + `initial_cards` agree.

**Cannot be unset.** `initial_cards=0` clears it, following the `max_cards` no-preference idiom.

**Rematch inheritance.** Now intentional rather than accidental. A rematch inherits the rule, which is what you want for a challenge or an agreed handicap — and the resolver is roster-relative, so counts clamp to the new game's `max_cards` and unnamed players open with 1. An inherited rule adapts instead of failing, and `initial_cards=0` clears it. Documented.

**Nickname validation.** Names must already be in the game; unknown ones are refused with the existing `Target player not found in this game` wording, so clients that suffix-match it need no new case.

**Documentation.** `api/README.md` — the parameter, the three forms, four sample calls, and notes covering order-independence, rematch behaviour and visibility.

**Comment brevity.** Cut hard. The previous revision argued the same point in five places; `shared/game.py`'s helper is now a nine-line docstring and the repetition is gone.

**And a correction of my own:** I claimed in the previous description that this repo had no test suite. It does — `api/test/`, and `test_validation.py` already covered `change_rules`. That was my error. The new cases live there rather than in ad-hoc scripts.

## The guard is deliberately gone

The previous revision refused uneven openings unless every seat but one was an AI. That was too blunt: symmetric openings are harmless anywhere, and asymmetric ones are a legitimate handicap between humans, not only a challenge against bots. Uneven openings are visible to everyone in the `rules` field before the game starts, which is noted in the README so clients can surface them.

## Behaviour when absent

Byte-for-byte what it was, for every existing game.

## Verification

`test_validation.py` gains the three forms, the unset, unknown-nickname refusal, unparseable input, an above-`max_cards` refusal, and the order-independence check. Those are integration tests, so they need a deployed environment.

Locally I also exercised the pure parser, validator and resolver directly:

| case | result |
|---|---|
| `0` / empty | unset |
| `2` / `random` / `RANDOM` | shared count, random (case-insensitive) |
| `You:10,Morana_(AI):2` | named counts |
| nickname containing a colon | parsed correctly (`rpartition`) |
| `garbage`, `You:`, `:3`, `2.5` | refused |
| count above `max_cards` | refused, not clamped |
| unknown nickname | refused |
| handicap between two humans | **allowed** |
| resolver: no rule / shared / random / named | 1 each / N each / within 1…max / unnamed default to 1 |
| resolver: stale inherited count | clamped, start still succeeds |
| resolver: DynamoDB `Decimal` values | coerce cleanly |

## Not deployed

Needs a `deployment/deploy.sh` run on `$LATEST` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcvn3cx4ZuCv9ty2ADZ3HR