### PR TITLE
Enable joining straight into a team

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -58,7 +58,7 @@ curl <HOST>/games/create
   `"avatar_mask"=string`, `"avatar_material"=string` (see [Avatars](#avatars))
   `"team"=integer` (1, 2, 3, or 4. Omit to join as an independent player)
 
-  Joining straight into a team is equivalent to joining and then calling [Change team](#change-team), and likewise resets the readiness of all human players to `false`. It lets a client restore a team without the player first appearing as independent, which matters when a whole table rejoins for a rematch.
+  Joining straight into a team is equivalent to joining and then calling [Change team](#change-team), and likewise resets the readiness of all human players to `false`.
 
 * **Success Response:**
 

--- a/api/README.md
+++ b/api/README.md
@@ -16,6 +16,7 @@
   `"previous_game_uuid"=string` (Used for rematches)
   `"previous_player_uuid"=string` (Used for rematches)
   `"avatar_mask"=string`, `"avatar_material"=string` (Only used when joining via `nickname`; see [Avatars](#avatars))
+  `"team"=integer` (1, 2, 3, or 4. Omit to be independent. Requires `nickname` — supplying it without one is an error)
 
 * **URL Params**
 
@@ -55,6 +56,9 @@ curl <HOST>/games/create
   **Optional:**
 
   `"avatar_mask"=string`, `"avatar_material"=string` (see [Avatars](#avatars))
+  `"team"=integer` (1, 2, 3, or 4. Omit to join as an independent player)
+
+  Joining straight into a team is equivalent to joining and then calling [Change team](#change-team), and likewise resets the readiness of all human players to `false`. It lets a client restore a team without the player first appearing as independent, which matters when a whole table rejoins for a rematch.
 
 * **Success Response:**
 
@@ -70,6 +74,9 @@ curl <HOST>/games/create
 
 ```
 curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&avatar_mask=wolf&avatar_material=amber
+
+# Joining straight into Team 2
+curl <HOST>/games/f2fdd601-bc82-438b-a4ee-a871dc35561a/join?nickname=coolcat&team=2
 ```
 
 ### Avatars

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -5,7 +5,7 @@ import time
 from botocore.exceptions import ClientError
 from shared.response import error_payload, internal_error_payload, parameter_error_payload, request_error_payload, response_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
-from shared.inputs import parse_nickname
+from shared.inputs import parse_nickname, parse_team
 from shared.constants import GameStatus, RuleValues, validate_avatar
 from shared.db import get_from_dynamodb, save_in_dynamodb, table
 from shared.game import create_player
@@ -112,6 +112,8 @@ def lambda_handler(event, context):
 
         nickname = body.get("nickname")
         if not nickname:
+            if body.get("team") is not None:
+                return parameter_error_payload("team", body.get("team"), message="Team can only be set when joining with a nickname")
             if save_in_dynamodb(game):
                 return response_payload(200, {"game_uuid": game_uuid})
             raise Exception("Failed to save game")
@@ -129,7 +131,12 @@ def lambda_handler(event, context):
         if avatar_error:
             return parameter_error_payload("avatar", None, message=avatar_error)
 
-        player = create_player(game, nickname, avatar)
+        try:
+            team = parse_team(body.get("team"))
+        except ValueError as err:
+            return parameter_error_payload("team", body.get("team"), message=str(err))
+
+        player = create_player(game, nickname, avatar, team)
         game.update({"players": [player], "admin_nickname": player.get("nickname")})
         if save_in_dynamodb(game):
             return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player.get("uuid")})

--- a/api/create_game.py
+++ b/api/create_game.py
@@ -60,6 +60,15 @@ def lambda_handler(event, context):
         if not body:
             return request_error_payload(event)
 
+        # Before register_rematch, which writes to the previous game: a rejection
+        # after that point leaves it pointing at a game that is never saved.
+        if body.get("team") is not None and not body.get("nickname"):
+            return parameter_error_payload("team", body.get("team"), message="Team can only be set when joining with a nickname")
+        try:
+            team = parse_team(body.get("team"))
+        except ValueError as err:
+            return parameter_error_payload("team", body.get("team"), message=str(err))
+
         game_uuid = str(uuid.uuid4())
         prev_game_uuid = body.get("previous_game_uuid")
         prev_player_uuid = body.get("previous_player_uuid")
@@ -112,8 +121,6 @@ def lambda_handler(event, context):
 
         nickname = body.get("nickname")
         if not nickname:
-            if body.get("team") is not None:
-                return parameter_error_payload("team", body.get("team"), message="Team can only be set when joining with a nickname")
             if save_in_dynamodb(game):
                 return response_payload(200, {"game_uuid": game_uuid})
             raise Exception("Failed to save game")
@@ -130,11 +137,6 @@ def lambda_handler(event, context):
         avatar, avatar_error = validate_avatar(body)
         if avatar_error:
             return parameter_error_payload("avatar", None, message=avatar_error)
-
-        try:
-            team = parse_team(body.get("team"))
-        except ValueError as err:
-            return parameter_error_payload("team", body.get("team"), message=str(err))
 
         player = create_player(game, nickname, avatar, team)
         game.update({"players": [player], "admin_nickname": player.get("nickname")})

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -3,10 +3,10 @@ import decimal
 from botocore.exceptions import ClientError
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
-from shared.inputs import parse_nickname
+from shared.inputs import parse_nickname, parse_team
 from shared.db import table
 from shared.constants import GameStatus, validate_avatar
-from shared.game import create_player, calculate_actual_max_cards
+from shared.game import create_player, calculate_actual_max_cards, unset_human_readiness
 from shared.decorators import validate_game_request
 from shared.logging import logger
 
@@ -64,8 +64,15 @@ def lambda_handler(event, context, body, game):
         if avatar_error:
             return parameter_error_payload("avatar", None, message=avatar_error)
 
-        new_player = create_player(game, nickname, avatar)
+        try:
+            team = parse_team(body.get("team"))
+        except ValueError as err:
+            return parameter_error_payload("team", body.get("team"), message=str(err))
+
+        new_player = create_player(game, nickname, avatar, team)
         players.append(new_player)
+        if team is not None:
+            players = unset_human_readiness(players)
         admin_nickname = game.get("admin_nickname") or new_player.get("nickname")
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
 

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -11,7 +11,7 @@ from .time_limit import send_time_limit_message
 from .logging import logger
 from .constants import GameStatus, CommonCardsRules, RuleValues, random_avatar
 
-def create_player(game, nickname, avatar=None):
+def create_player(game, nickname, avatar=None, team=None):
     players = game.get("players")
     ready = False if len(players) == 0 or game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_DEFAULT) != RuleValues.TIME_LIMIT_NO_LIMIT else True
     return {
@@ -19,7 +19,7 @@ def create_player(game, nickname, avatar=None):
         "nickname": nickname,
         "n_cards": 0,
         "ready": ready,
-        "team": None,
+        "team": team,
         "avatar": avatar if avatar is not None else random_avatar()
     }
 

--- a/api/test/test_validation.py
+++ b/api/test/test_validation.py
@@ -266,5 +266,27 @@ class TestAPIValidation(unittest.TestCase):
         resp = self.session.get(f"{BASE_URL}/games/create", params={"nickname": "Bad3", "team": 9})
         self.assertEqual(resp.status_code, 400, resp.text)
 
+    def test_rejected_team_does_not_consume_the_rematch(self):
+        """A rejected team must not leave the previous game pointing at a game
+        that was never saved. The rematch link can only be claimed once, so a
+        request that fails after claiming it would brick rematches for good."""
+        self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Bob"})
+
+        resp = self.session.get(f"{BASE_URL}/games/create",
+                                params={"previous_game_uuid": self.game_uuid,
+                                        "previous_player_uuid": self.admin_uuid, "team": 2})
+        self.assertEqual(resp.status_code, 400, resp.text)
+
+        # The link must still be free, and a genuine rematch must reach a real game.
+        resp = self.session.get(f"{BASE_URL}/games/create",
+                                params={"previous_game_uuid": self.game_uuid,
+                                        "previous_player_uuid": self.admin_uuid,
+                                        "nickname": "AdminUser"})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        rematch_uuid = resp.json()["game_uuid"]
+        state = self.session.get(f"{BASE_URL}/games/{rematch_uuid}")
+        self.assertEqual(state.status_code, 200,
+                         "the rematch points at a game that does not exist")
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/api/test/test_validation.py
+++ b/api/test/test_validation.py
@@ -217,5 +217,54 @@ class TestAPIValidation(unittest.TestCase):
                 self.assertEqual(resp.status_code, 400, f"{bad!r} -> {resp.text}")
                 self.assertIn("must start with a letter", resp.json().get("error", ""))
 
+    # ---------------------------------------------------------
+    # JOINING STRAIGHT INTO A TEAM
+    # ---------------------------------------------------------
+
+    def _player(self, game_uuid, nickname):
+        state = self.session.get(f"{BASE_URL}/games/{game_uuid}", params={"player_uuid": self.admin_uuid}).json()
+        return next(p for p in state["players"] if p["nickname"] == nickname)
+
+    def test_join_with_team_seats_the_player(self):
+        """A team supplied on join is applied without a follow-up change-team call."""
+        resp = self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Teamed", "team": 2})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(self._player(self.game_uuid, "Teamed")["team"], 2)
+
+    def test_join_without_team_is_independent(self):
+        """Omitting the team keeps the previous behaviour: an independent player."""
+        resp = self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Loner"})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertIsNone(self._player(self.game_uuid, "Loner")["team"])
+
+    def test_join_with_team_resets_human_readiness(self):
+        """Joining into a team is equivalent to join + change-team, so it unreadies humans."""
+        self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Early"})
+        self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Teamed", "team": 3})
+        self.assertFalse(self._player(self.game_uuid, "Early")["ready"])
+
+    def test_create_with_nickname_and_team(self):
+        """The creator can claim a team in the same call."""
+        resp = self.session.get(f"{BASE_URL}/games/create", params={"nickname": "Founder", "team": 1})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        state = self.session.get(f"{BASE_URL}/games/{resp.json()['game_uuid']}").json()
+        self.assertEqual(state["players"][0]["team"], 1)
+
+    def test_create_with_team_but_no_nickname_rejected(self):
+        """A team without a nickname creates no player, so it is an error rather than a silent no-op."""
+        resp = self.session.get(f"{BASE_URL}/games/create", params={"team": 1})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("only be set when joining with a nickname", resp.json().get("error", ""))
+
+    def test_invalid_team_rejected(self):
+        """Out-of-range and non-integer teams are rejected on both entry points."""
+        for params in [{"nickname": "Bad1", "team": 5}, {"nickname": "Bad2", "team": "green"}]:
+            with self.subTest(params=params):
+                resp = self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params=params)
+                self.assertEqual(resp.status_code, 400, resp.text)
+                self.assertIn("Team must be", resp.json().get("error", ""))
+        resp = self.session.get(f"{BASE_URL}/games/create", params={"nickname": "Bad3", "team": 9})
+        self.assertEqual(resp.status_code, 400, resp.text)
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Adds a simple `team` option to the create and join flows, with a bunch of tests