### PR TITLE
Register the rematch link in the same transaction that saves the game

### DIFF
--- a/api/create_game.py
+++ b/api/create_game.py
@@ -1,13 +1,11 @@
-import decimal
 import uuid
 import random
 import time
-from botocore.exceptions import ClientError
 from shared.response import error_payload, internal_error_payload, parameter_error_payload, request_error_payload, response_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
 from shared.inputs import parse_nickname, parse_team
 from shared.constants import GameStatus, RuleValues, validate_avatar
-from shared.db import get_from_dynamodb, save_in_dynamodb, table
+from shared.db import get_from_dynamodb, save_in_dynamodb, transact_create_rematch
 from shared.game import create_player
 from shared.api_gateway import parse_event
 
@@ -19,10 +17,11 @@ from shared.api_gateway import parse_event
 # so update_item handlers preserve it untouched.
 RETENTION_PERIOD_SECONDS = 365 * 24 * 60 * 60  # 365 days
 
-def register_rematch(prev_game, initiator_uuid, new_game_uuid):
+def check_rematch_eligibility(prev_game, initiator_uuid):
     """
-    Verifies the initiator was a player in the previous game and
-    atomically registers the rematch link.
+    Read-only pre-checks on a rematch request. Fails fast with the same errors
+    as before, but claims nothing: the link is claimed in the same transaction
+    that saves the new game, so a later rejection cannot strand it.
     """
     # Verify the initiator was a player in that game
     player_uuids = [p["uuid"] for p in prev_game.get("players", [])]
@@ -34,25 +33,23 @@ def register_rematch(prev_game, initiator_uuid, new_game_uuid):
     if existing_rematch:
         return False, existing_rematch, "Rematch already exists"
 
-    # Attempt atomic registration
-    try:
-        table.update_item(
-            Key={'game_uuid': prev_game["game_uuid"]},
-            UpdateExpression="SET next_game_uuid = :n, last_modified = :t",
-            ConditionExpression="attribute_not_exists(next_game_uuid) OR attribute_type(next_game_uuid, :null_type)",
-            ExpressionAttributeValues={
-                ':n': new_game_uuid,
-                ':t': decimal.Decimal(str(time.time())),
-                ':null_type': 'NULL'
-            }
-        )
-        return True, new_game_uuid, None
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            # Re-fetch only in case of a race condition to get the winner's UUID
-            updated_prev = get_from_dynamodb(prev_game["game_uuid"])
-            return False, updated_prev.get("next_game_uuid"), "Rematch already exists"
-        raise
+    return True, None, None
+
+def save_game(game, prev_game_uuid):
+    """
+    Persists a newly created game. For a rematch this also claims the previous
+    game's link, atomically. Returns (saved, winner_uuid): a False with a
+    winner_uuid means another rematch won the race.
+    """
+    if not prev_game_uuid:
+        return save_in_dynamodb(game), None
+
+    if transact_create_rematch(game, prev_game_uuid):
+        return True, None
+
+    # Lost the race - re-read to find who won.
+    updated_prev = get_from_dynamodb(prev_game_uuid)
+    return False, (updated_prev or {}).get("next_game_uuid")
 
 def lambda_handler(event, context):
     try:
@@ -60,8 +57,7 @@ def lambda_handler(event, context):
         if not body:
             return request_error_payload(event)
 
-        # Before register_rematch, which writes to the previous game: a rejection
-        # after that point leaves it pointing at a game that is never saved.
+        # Cheap checks first, before the previous game is even read.
         if body.get("team") is not None and not body.get("nickname"):
             return parameter_error_payload("team", body.get("team"), message="Team can only be set when joining with a nickname")
         try:
@@ -96,12 +92,12 @@ def lambda_handler(event, context):
             if not prev_player_uuid:
                 return parameter_error_payload("previous_player_uuid", None, "Required for rematch")
 
-            success, final_uuid, error_msg = register_rematch(prev_game, prev_player_uuid, game_uuid)
-            if not success:
+            eligible, final_uuid, error_msg = check_rematch_eligibility(prev_game, prev_player_uuid)
+            if not eligible:
                 if final_uuid: # Someone else already created it
                     return response_payload(200, {"game_uuid": final_uuid, "message": error_msg})
                 return error_payload(403, error_msg) # Unauthorized or missing game
-            
+
         game = {
             "game_uuid": game_uuid,
             "next_game_uuid": None,
@@ -121,8 +117,11 @@ def lambda_handler(event, context):
 
         nickname = body.get("nickname")
         if not nickname:
-            if save_in_dynamodb(game):
+            saved, winner_uuid = save_game(game, prev_game_uuid)
+            if saved:
                 return response_payload(200, {"game_uuid": game_uuid})
+            if winner_uuid:
+                return response_payload(200, {"game_uuid": winner_uuid, "message": "Rematch already exists"})
             raise Exception("Failed to save game")
 
         # If the user wants to join at the same time
@@ -140,8 +139,11 @@ def lambda_handler(event, context):
 
         player = create_player(game, nickname, avatar, team)
         game.update({"players": [player], "admin_nickname": player.get("nickname")})
-        if save_in_dynamodb(game):
+        saved, winner_uuid = save_game(game, prev_game_uuid)
+        if saved:
             return response_payload(200, {"game_uuid": game_uuid, "player_uuid": player.get("uuid")})
+        if winner_uuid:
+            return response_payload(200, {"game_uuid": winner_uuid, "message": "Rematch already exists"})
 
         raise Exception("Something went wrong - ended up with no response")
 

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -73,3 +73,47 @@ def transact_end_of_round(live_game_state, archive_game_state, last_modified_con
             return False
         else:
             raise
+
+def transact_create_rematch(new_game, prev_game_uuid):
+    """
+    Saves the rematch game and claims the link on the previous game in a single
+    transaction. Either both land or neither does, so a failure can never leave
+    the previous game pointing at a game that was not saved. Claiming the link
+    is one-shot, so such a pointer would be permanent.
+
+    Returns True on success, False if the previous game's link was already
+    claimed (the caller re-reads it to find the winner).
+    """
+    new_game["last_modified"] = decimal.Decimal(str(time.time()))
+
+    try:
+        table.meta.client.transact_write_items(TransactItems=[
+            {
+                'Put': {
+                    'TableName': table.name,
+                    'Item': new_game,
+                    'ConditionExpression': 'attribute_not_exists(game_uuid)'
+                }
+            },
+            {
+                'Update': {
+                    'TableName': table.name,
+                    'Key': {'game_uuid': prev_game_uuid},
+                    'UpdateExpression': "SET next_game_uuid = :n, last_modified = :t",
+                    'ConditionExpression': "attribute_not_exists(next_game_uuid) OR attribute_type(next_game_uuid, :null_type)",
+                    'ExpressionAttributeValues': {
+                        ':n': new_game["game_uuid"],
+                        ':t': decimal.Decimal(str(time.time())),
+                        ':null_type': 'NULL'
+                    }
+                }
+            }
+        ])
+        return True
+
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'TransactionCanceledException':
+            logger.warning(f"Rematch registration lost the race for game {prev_game_uuid}.")
+            return False
+        else:
+            raise

--- a/api/test/test_validation.py
+++ b/api/test/test_validation.py
@@ -376,27 +376,49 @@ class TestAPIValidation(unittest.TestCase):
         resp = self.session.get(f"{BASE_URL}/games/create", params={"nickname": "Bad3", "team": 9})
         self.assertEqual(resp.status_code, 400, resp.text)
 
-    def test_rejected_team_does_not_consume_the_rematch(self):
-        """A rejected team must not leave the previous game pointing at a game
-        that was never saved. The rematch link can only be claimed once, so a
-        request that fails after claiming it would brick rematches for good."""
+    def test_rejected_rematch_does_not_consume_the_link(self):
+        """No rejected create may leave the previous game pointing at a game that
+        was never saved. The link can only be claimed once, so a request that
+        fails after claiming it would brick rematches for that game for good."""
         self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join", params={"nickname": "Bob"})
+        rematch_params = {"previous_game_uuid": self.game_uuid,
+                          "previous_player_uuid": self.admin_uuid}
 
-        resp = self.session.get(f"{BASE_URL}/games/create",
-                                params={"previous_game_uuid": self.game_uuid,
-                                        "previous_player_uuid": self.admin_uuid, "team": 2})
-        self.assertEqual(resp.status_code, 400, resp.text)
+        for label, bad in [("team without nickname", {"team": 2}),
+                           ("invalid team", {"nickname": "AdminUser", "team": 9}),
+                           ("malformed nickname", {"nickname": "1nvalid"}),
+                           ("bad avatar", {"nickname": "AdminUser", "avatar_material": "plastic"})]:
+            with self.subTest(case=label):
+                resp = self.session.get(f"{BASE_URL}/games/create", params={**rematch_params, **bad})
+                self.assertEqual(resp.status_code, 400, resp.text)
 
         # The link must still be free, and a genuine rematch must reach a real game.
         resp = self.session.get(f"{BASE_URL}/games/create",
-                                params={"previous_game_uuid": self.game_uuid,
-                                        "previous_player_uuid": self.admin_uuid,
-                                        "nickname": "AdminUser"})
+                                params={**rematch_params, "nickname": "AdminUser"})
         self.assertEqual(resp.status_code, 200, resp.text)
         rematch_uuid = resp.json()["game_uuid"]
         state = self.session.get(f"{BASE_URL}/games/{rematch_uuid}")
         self.assertEqual(state.status_code, 200,
                          "the rematch points at a game that does not exist")
+
+    def test_second_rematch_returns_the_first(self):
+        """The link is claimed once. A later attempt reports the winner rather
+        than overwriting it or creating an orphan."""
+        bob_uuid = self.session.get(f"{BASE_URL}/games/{self.game_uuid}/join",
+                                    params={"nickname": "Bob"}).json()["player_uuid"]
+        rematch_params = {"previous_game_uuid": self.game_uuid}
+
+        first = self.session.get(f"{BASE_URL}/games/create",
+                                 params={**rematch_params, "previous_player_uuid": self.admin_uuid,
+                                         "nickname": "AdminUser"})
+        self.assertEqual(first.status_code, 200, first.text)
+
+        second = self.session.get(f"{BASE_URL}/games/create",
+                                  params={**rematch_params, "previous_player_uuid": bob_uuid,
+                                          "nickname": "Bob"})
+        self.assertEqual(second.status_code, 200, second.text)
+        self.assertEqual(second.json()["game_uuid"], first.json()["game_uuid"],
+                         "the second rematch must land in the first one's game")
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
*(Written by Claude, working with Adrian.)*

Follow-up to the ordering fix in #237. That moved the `team` checks above the rematch claim; this closes the class properly.

## The problem

`register_rematch` wrote `next_game_uuid` on the **previous** game before the new game was validated or saved. Anything that failed afterwards — a malformed nickname, profanity, a bad avatar, an unexpected exception between the claim and `save_in_dynamodb` — left the previous game pointing at a game that never existed.

The claim is one-shot (`attribute_not_exists(next_game_uuid) OR attribute_type(..., NULL)`), so it cannot be retried. Every later rematch on that game then returned **200 with a uuid that resolves to nothing**. Permanent for that lobby.

Hoisting individual checks, as #237 did for `team`, only ever fixes the failures you remember to hoist. It cannot fix an exception, and it cannot fix the race.

## The change

`register_rematch` splits in two:

- **`check_rematch_eligibility`** — the read-only pre-checks (was the initiator a player; is a rematch already registered), with their existing errors and response codes unchanged. It now claims nothing.
- **`transact_create_rematch`** (`shared/db.py`) — `Put` of the new game plus the conditional `Update` of the previous game's link, in one `transact_write_items`. Either both land or neither does.

This mirrors `transact_end_of_round`, which already uses the same two-item pattern in this codebase.

`save_game` picks the path: a plain put for an ordinary create, the transaction for a rematch. On cancellation it re-reads the previous game and returns the winner's uuid — exactly the previous behaviour.

Also retires `decimal`, `ClientError` and `table` from `create_game`, now unused.

## What this buys beyond #237

The eligibility check and the save are no longer the same instant, so a competitor can claim the link in between. Only the transaction's condition catches that. Previously the loser would have saved its game and returned its own uuid while the previous game pointed elsewhere; now the loser writes nothing and reports the winner.

## Verification

Drove the real handlers (`create_game`, `join_game`) against an in-memory table with an all-or-nothing `transact_write_items` stand-in. 17 checks: all four rejection paths leave the link untouched, the genuine rematch links to a game that exists with rules inherited and the creator seated, a second rematch returns the first's uuid without overwriting, a link claimed **mid-request** yields the winner and saves nothing, and non-rematch create/join are unaffected.

Against `develop` the same suite fails 4 checks — malformed nickname, bad avatar, and the two mid-request race assertions. The two `team` cases pass there, since #237 already fixed those. So the suite is measuring exactly what this PR adds.

Committed coverage: `test_rejected_rematch_does_not_consume_the_link` (generalises the team-only test from #237 to all four rejection paths) and `test_second_rematch_returns_the_first`.

## Notes

- Transactions cost 2× the write units. Rematch creation is one of the rarest writes in the system, so this is not a meaningful cost.
- The non-rematch create path deliberately stays a plain `put` — there is nothing to make atomic with.
- Not deployed. Needs `deployment/deploy.sh` after merge.