### PR TITLE
Guard lobby players writes with optimistic locking

### DIFF
--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -1,36 +1,9 @@
-import time
-import decimal
-from shared.response import response_payload, parameter_error_payload, internal_error_payload
-from shared.db import table
+from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus, RuleValues, CommonCardsRules
 from shared.game import unset_human_readiness, calculate_actual_max_cards
 from shared.decorators import validate_game_request
 from shared.logging import logger
-
-def update_in_dynamodb(game_uuid, rules, players, max_cards=None):
-    """
-    Updates the game rules, player readiness, and max cards in DynamoDB.
-    """
-    update_expressions = ["#rules = :rules", "players = :players", "last_modified = :last_modified"]
-    expression_attribute_names = {'#rules': 'rules'}
-    expression_attribute_values = {
-        ':rules': rules,
-        ':players': players,
-        ':last_modified': decimal.Decimal(str(time.time()))
-    }
-
-    if max_cards is not None:
-        update_expressions.append("max_cards = :max_cards")
-        expression_attribute_values[':max_cards'] = max_cards
-
-    table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression="set " + ", ".join(update_expressions),
-        ExpressionAttributeNames=expression_attribute_names,
-        ExpressionAttributeValues=expression_attribute_values,
-        ReturnValues="NONE"
-    )
-    return True
 
 @validate_game_request(
     require_admin=True, 
@@ -108,7 +81,8 @@ def lambda_handler(event, context, body, game):
 
         logger.info(f'## NEW RULES: {rules}')
         logger.info(f'## MAX CARDS: {max_cards}')
-        update_in_dynamodb(game["game_uuid"], rules, players, max_cards)
+        if not update_players_conditionally(game["game_uuid"], players, game["last_modified"], rules=rules, max_cards=max_cards):
+            return error_payload(409, "The game state changed. Please try again.")
 
         return response_payload(200, {"message": "Rules updated"})
 

--- a/api/change_team.py
+++ b/api/change_team.py
@@ -1,23 +1,9 @@
-import time
-import decimal
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
-from shared.db import table
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import get_player_by_nickname, unset_human_readiness
 from shared.inputs import parse_team
 from shared.decorators import validate_game_request
-
-def update_in_dynamodb(game_uuid, players):
-    """ Updates the players list in DynamoDB. """
-    table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression="SET players = :p, last_modified = :t",
-        ExpressionAttributeValues={
-            ':p': players,
-            ':t': decimal.Decimal(str(time.time()))
-        }
-    )
-    return True
 
 @validate_game_request(
     require_player=True, 
@@ -52,7 +38,8 @@ def lambda_handler(event, context, body, game):
         target_player["team"] = new_team
         players = unset_human_readiness(players)
 
-        update_in_dynamodb(game["game_uuid"], players)
+        if not update_players_conditionally(game["game_uuid"], players, game["last_modified"]):
+            return error_payload(409, "The game state changed. Please try again.")
 
         return response_payload(200, {"message": f"Player {target_nickname} team changed successfully"})
 

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -1,31 +1,14 @@
 import os
-import time
 import json
 import uuid
-import decimal
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
-from shared.db import table
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards, unset_human_readiness
 from shared.inputs import parse_team
 from shared.decorators import validate_game_request
 
 AGENT_MAPPING = json.loads(os.environ.get("agent_mapping"))
-
-def update_in_dynamodb(game_uuid, players, max_cards):
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set players = :players, last_modified = :last_modified, max_cards = :mc",
-        ExpressionAttributeValues={
-            ':players': players,
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':mc': max_cards
-        },
-        ReturnValues="NONE"
-    )
-    return True
 
 
 def format_name(agent_name, num):
@@ -80,7 +63,8 @@ def lambda_handler(event, context, body, game):
             players = unset_human_readiness(players)
 
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
-        update_in_dynamodb(game["game_uuid"], players, max_cards)
+        if not update_players_conditionally(game["game_uuid"], players, game["last_modified"], max_cards=max_cards):
+            return error_payload(409, "The game state changed. Please try again.")
 
         return response_payload(200, {"message": f"{nickname} joined the game"})
 

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -1,40 +1,11 @@
-import time
-import decimal
-from botocore.exceptions import ClientError
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
 from shared.inputs import parse_nickname, parse_team
-from shared.db import table
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus, validate_avatar
 from shared.game import create_player, calculate_actual_max_cards, unset_human_readiness
 from shared.decorators import validate_game_request
 from shared.logging import logger
-
-def update_in_dynamodb(game_uuid, players, admin_nickname, max_cards, last_modified):
-    """
-    Conditionally updates the game state in DynamoDB to add a new player.
-    Returns True on success, False on failure (due to a race condition).
-    """
-    try:
-        table.update_item(
-            Key={'game_uuid': game_uuid},
-            UpdateExpression="SET players = :p, last_modified = :t, admin_nickname = :a, max_cards = :mc",
-            ConditionExpression="last_modified = :lm",
-            ExpressionAttributeValues={
-                ':p': players,
-                ':t': decimal.Decimal(str(time.time())),
-                ':a': admin_nickname,
-                ':mc': max_cards,
-                ':lm': last_modified
-            }
-        )
-        return True
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            logger.warning(f"Failed to join game {game_uuid} due to a race condition.")
-            return False
-        else:
-            raise
 
 @validate_game_request(
     required_status=GameStatus.NOT_STARTED, 
@@ -76,7 +47,7 @@ def lambda_handler(event, context, body, game):
         admin_nickname = game.get("admin_nickname") or new_player.get("nickname")
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
 
-        if update_in_dynamodb(game["game_uuid"], players, admin_nickname, max_cards, game["last_modified"]):
+        if update_players_conditionally(game["game_uuid"], players, game["last_modified"], admin_nickname=admin_nickname, max_cards=max_cards):
             return response_payload(200, {"player_uuid": new_player.get("uuid")})
         
         logger.info(f"Join failed for '{nickname}' due to race condition.")

--- a/api/remove_ais.py
+++ b/api/remove_ais.py
@@ -1,25 +1,8 @@
-import time
-import decimal
-from shared.response import response_payload, internal_error_payload
-from shared.db import table
+from shared.response import response_payload, error_payload, internal_error_payload
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards
 from shared.decorators import validate_game_request
-
-def update_in_dynamodb(game_uuid, players, max_cards):
-    table.update_item(
-        Key={
-            'game_uuid': game_uuid
-        },
-        UpdateExpression="set players = :players, max_cards = :mc, last_modified = :last_modified",
-        ExpressionAttributeValues={
-            ':players': players,
-            ':mc': max_cards,
-            ':last_modified': decimal.Decimal(str(time.time()))
-        },
-        ReturnValues="NONE"
-    )
-    return True
 
 @validate_game_request(
     require_admin=True, 
@@ -36,7 +19,8 @@ def lambda_handler(event, context, body, game):
         
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(human_players))
 
-        update_in_dynamodb(game["game_uuid"], human_players, max_cards)
+        if not update_players_conditionally(game["game_uuid"], human_players, game["last_modified"], max_cards=max_cards):
+            return error_payload(409, "The game state changed. Please try again.")
 
         return response_payload(200, {"message": "All AI players have been removed."})
 

--- a/api/remove_player.py
+++ b/api/remove_player.py
@@ -1,24 +1,8 @@
-import time
-import decimal
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
-from shared.db import table
+from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards, get_player_by_nickname
 from shared.decorators import validate_game_request
-
-def update_in_dynamodb(game_uuid, players, admin_nickname, max_cards):
-    """ Updates the players list, admin, and max_cards in DynamoDB. """
-    table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression="SET players = :p, admin_nickname = :a, max_cards = :mc, last_modified = :t",
-        ExpressionAttributeValues={
-            ':p': players,
-            ':a': admin_nickname,
-            ':mc': max_cards,
-            ':t': decimal.Decimal(str(time.time()))
-        }
-    )
-    return True
 
 @validate_game_request(
     require_player=True, 
@@ -59,7 +43,8 @@ def lambda_handler(event, context, body, game):
         rules = game.get("rules", {})
         max_cards = calculate_actual_max_cards(rules, len(new_players))
 
-        update_in_dynamodb(game["game_uuid"], new_players, new_admin, max_cards)
+        if not update_players_conditionally(game["game_uuid"], new_players, game["last_modified"], admin_nickname=new_admin, max_cards=max_cards):
+            return error_payload(409, "The game state changed. Please try again.")
 
         return response_payload(200, {"message": f"Player {target_nickname} removed successfully"})
 

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -37,6 +37,44 @@ def save_in_dynamodb(obj, game_uuid=None, last_modified_condition=None):
         else:
             raise
 
+def update_players_conditionally(game_uuid, players, last_modified, **extra):
+    """
+    Replaces the players list (plus any extra top-level attributes) only if the
+    game has not been modified since it was read, so a concurrent lobby write
+    cannot be silently lost. Returns True on success, False if another write
+    landed in between (the caller should surface a 409 or retry).
+    """
+    update_parts = ["players = :players", "last_modified = :t"]
+    attribute_names = {}
+    attribute_values = {
+        ':players': players,
+        ':t': decimal.Decimal(str(time.time())),
+        ':lm': last_modified
+    }
+    for i, (attr, value) in enumerate(extra.items()):
+        attribute_names[f"#e{i}"] = attr
+        attribute_values[f":e{i}"] = value
+        update_parts.append(f"#e{i} = :e{i}")
+
+    update_params = {
+        'Key': {'game_uuid': game_uuid},
+        'UpdateExpression': "SET " + ", ".join(update_parts),
+        'ConditionExpression': "last_modified = :lm",
+        'ExpressionAttributeValues': attribute_values
+    }
+    if attribute_names:
+        update_params['ExpressionAttributeNames'] = attribute_names
+
+    try:
+        table.update_item(**update_params)
+        return True
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            logger.warning(f"Conditional players update failed for game_uuid: {game_uuid} due to a race condition.")
+            return False
+        else:
+            raise
+
 def transact_end_of_round(live_game_state, archive_game_state, last_modified_condition):
     """
     Atomically updates the live game state and saves the round archive using a transaction.

--- a/api/test/test_db.py
+++ b/api/test/test_db.py
@@ -1,0 +1,79 @@
+# Unit tests for shared.db.update_players_conditionally.
+# No network / AWS needed (the DynamoDB table is stubbed). Run from the api/ directory:
+#   python -m unittest test.test_db
+# or directly:
+#   python test/test_db.py
+import os
+import sys
+import decimal
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import shared.db as db  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+
+
+class FakeTable:
+    def __init__(self, error_code=None):
+        self.error_code = error_code
+        self.calls = []
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error_code:
+            raise ClientError({'Error': {'Code': self.error_code}}, 'UpdateItem')
+
+
+class TestUpdatePlayersConditionally(unittest.TestCase):
+
+    def setUp(self):
+        self.real_table = db.table
+        self.players = [{"nickname": "A"}, {"nickname": "B"}]
+        self.last_modified = decimal.Decimal("1722600000.0")
+
+    def tearDown(self):
+        db.table = self.real_table
+
+    def test_success_returns_true_and_guards_on_last_modified(self):
+        db.table = fake = FakeTable()
+        result = db.update_players_conditionally("uuid-1", self.players, self.last_modified)
+        self.assertTrue(result)
+
+        call = fake.calls[0]
+        self.assertEqual(call['Key'], {'game_uuid': "uuid-1"})
+        self.assertEqual(call['ConditionExpression'], "last_modified = :lm")
+        self.assertEqual(call['ExpressionAttributeValues'][':lm'], self.last_modified)
+        self.assertEqual(call['ExpressionAttributeValues'][':players'], self.players)
+        self.assertNotIn('ExpressionAttributeNames', call)
+
+    def test_extra_attributes_ride_along_via_name_placeholders(self):
+        db.table = fake = FakeTable()
+        db.update_players_conditionally(
+            "uuid-1", self.players, self.last_modified,
+            rules={"deck_size": 24}, max_cards=5, admin_nickname=None)
+
+        call = fake.calls[0]
+        names = call['ExpressionAttributeNames']
+        values = call['ExpressionAttributeValues']
+        # Every extra attribute is written through a name placeholder (so
+        # reserved words like "rules" are safe) with a matching value.
+        written = {names[placeholder]: values[placeholder.replace('#', ':')]
+                   for placeholder in names}
+        self.assertEqual(written, {"rules": {"deck_size": 24}, "max_cards": 5, "admin_nickname": None})
+        for placeholder in names:
+            self.assertIn(f"{placeholder} = {placeholder.replace('#', ':')}", call['UpdateExpression'])
+
+    def test_lost_race_returns_false(self):
+        db.table = FakeTable(error_code='ConditionalCheckFailedException')
+        result = db.update_players_conditionally("uuid-1", self.players, self.last_modified)
+        self.assertFalse(result)
+
+    def test_other_client_errors_propagate(self):
+        db.table = FakeTable(error_code='ProvisionedThroughputExceededException')
+        with self.assertRaises(ClientError):
+            db.update_players_conditionally("uuid-1", self.players, self.last_modified)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #239.

## Problem

Five lobby handlers (`invite-aiagent`, `change_team`, `change_rules`, `remove_player`, `remove_ais`) replaced the entire `players` list with an unconditional write. Any write landing between their read and their write was silently lost — e.g. a player who joined while the admin was summoning an AI vanished from the lobby while still holding a `player_uuid` the engine no longer recognised. `join_game` was the only handler already guarding against this.

## Change

- New `update_players_conditionally(game_uuid, players, last_modified, **extra)` in `shared/db.py`: writes `players` plus any ride-along attributes (`max_cards`, `rules`, `admin_nickname`) behind `ConditionExpression="last_modified = :lm"`, returning `False` on `ConditionalCheckFailedException`. Extra attributes go through name placeholders, so reserved words like `rules` are safe.
- All five handlers now pass the `last_modified` the decorator read and return **409 "The game state changed. Please try again."** on a lost race — the same response `join_game` already gives, so clients that handle a join 409 handle these too.
- `join_game` is refactored onto the helper, removing the last duplicated copy of this write.
- Each handler writes exactly the same attribute set as before; the only behavioural change is the added condition and the 409 path. (`change_rules`' old `max_cards is not None` guard was dead code — `calculate_actual_max_cards` always returns an int.)

## Tests

New `api/test/test_db.py` (4 tests, stubbed table, no AWS): asserts the condition expression and its values, extras riding through placeholders, `False` on a lost race, and other `ClientError`s propagating. Note it imports `shared/db.py`, so unlike the other pure-stdlib tests it needs `boto3` installed locally.

## Out of scope

Two adjacent races remain on the readiness path, same shape but not among the issue's five: `set_readiness` writes `players[i].ready` by index without a condition, and `start_game` (`shared/game.py`) writes the whole `players` list unconditionally when the last player readies up. Tracked in #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwacccXNhfqPCGfPMfWFRz