### PR TITLE
Fix unhandled race condition in last round of timed game

### DIFF
--- a/api/play.py
+++ b/api/play.py
@@ -5,7 +5,7 @@ import boto3
 from botocore.exceptions import ClientError
 from itertools import combinations
 from shared.response import response_payload, error_payload, parameter_error_payload, internal_error_payload
-from shared.db import table
+from shared.db import table, RACE_LOST_ERROR_CODES
 from shared.constants import GameStatus, RuleValues
 from shared.logging import logger
 from shared.game import censor_game, find_next_active_player, end_round, start_player_timer, get_action_ids
@@ -196,8 +196,9 @@ def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modi
         )
         return True
     except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            logger.warning("Failed to update game state due to a race condition (play vs timeout).")
+        error_code = e.response['Error']['Code']
+        if error_code in RACE_LOST_ERROR_CODES:
+            logger.warning(f"Failed to update game state for {game_uuid} due to a race condition (play vs timeout): {error_code}.")
             return False
         else:
             raise

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -10,6 +10,9 @@ table = dynamodb.Table("games")
 websocket_table = dynamodb.Table("watch_game_websocket_manager")
 reports_table = dynamodb.Table("nickname_reports")
 
+# A write that lost a race rather than genuinely failing
+RACE_LOST_ERROR_CODES = ('ConditionalCheckFailedException', 'TransactionConflictException')
+
 def get_from_dynamodb(game_uuid):
     response = table.query(KeyConditionExpression=Key('game_uuid').eq(game_uuid))
     items = response.get("Items")


### PR DESCRIPTION
We recently had a 500 code in `play`, when somebody tried to send a bet in the last round of a game with a time limit but was too late.

Cause: when a player submits a non-check action, lambda_handler attempts to update DynamoDB using `update_in_dynamodb()`. During the last round, if a timeout occurs concurrently, the timeout process calls `end_round()`, which executes a transactional write via `transact_end_of_round()`. If update_item executes concurrently while the `transact_write_items` operation is in flight, DynamoDB raises a `TransactionConflictException`, which is unhandled.

This PR fixes that