### PR TITLE
Fix readiness race conditions

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,14 @@
 # HTTP API endpoints
 
+## Concurrent changes
+
+Endpoints that rewrite the player list, or the game as a whole, do so conditionally: the write is rejected if the game changed between the engine reading it and writing it back. When that happens, the endpoint responds:
+
+  * **Code:** 409 CONFLICT <br />
+  **Content:** `{"error":"The game state changed. Please try again."}`
+
+A 409 means nothing was written, so the call is safe to repeat. It can be returned by [Join game](#join-game), [Invite AI agent](#invite-ai-agent), [Remove AI agents](#remove-ai-agents), [Set readiness](#set-readiness), [Change rules](#change-rules), [Start game](#start-game), [Remove player](#remove-player), [Change team](#change-team) and [Play](#play).
+
 ## Create game
 
   Creates a game object with default rules. Optionally, allows joining the newly created game.

--- a/api/change_rules.py
+++ b/api/change_rules.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.response import response_payload, parameter_error_payload, conflict_payload, internal_error_payload
 from shared.db import update_players_conditionally
 from shared.constants import GameStatus, RuleValues, CommonCardsRules
 from shared.game import unset_human_readiness, calculate_actual_max_cards
@@ -82,7 +82,7 @@ def lambda_handler(event, context, body, game):
         logger.info(f'## NEW RULES: {rules}')
         logger.info(f'## MAX CARDS: {max_cards}')
         if not update_players_conditionally(game["game_uuid"], players, game["last_modified"], rules=rules, max_cards=max_cards):
-            return error_payload(409, "The game state changed. Please try again.")
+            return conflict_payload()
 
         return response_payload(200, {"message": "Rules updated"})
 

--- a/api/change_team.py
+++ b/api/change_team.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.response import response_payload, parameter_error_payload, error_payload, conflict_payload, internal_error_payload
 from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import get_player_by_nickname, unset_human_readiness
@@ -39,7 +39,7 @@ def lambda_handler(event, context, body, game):
         players = unset_human_readiness(players)
 
         if not update_players_conditionally(game["game_uuid"], players, game["last_modified"]):
-            return error_payload(409, "The game state changed. Please try again.")
+            return conflict_payload()
 
         return response_payload(200, {"message": f"Player {target_nickname} team changed successfully"})
 

--- a/api/invite-aiagent.py
+++ b/api/invite-aiagent.py
@@ -1,7 +1,7 @@
 import os
 import json
 import uuid
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.response import response_payload, parameter_error_payload, error_payload, conflict_payload, internal_error_payload
 from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards, unset_human_readiness
@@ -64,7 +64,7 @@ def lambda_handler(event, context, body, game):
 
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(players))
         if not update_players_conditionally(game["game_uuid"], players, game["last_modified"], max_cards=max_cards):
-            return error_payload(409, "The game state changed. Please try again.")
+            return conflict_payload()
 
         return response_payload(200, {"message": f"{nickname} joined the game"})
 

--- a/api/join_game.py
+++ b/api/join_game.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload, nickname_rejected_payload
+from shared.response import response_payload, parameter_error_payload, error_payload, conflict_payload, internal_error_payload, nickname_rejected_payload
 from shared.profanity_filter import is_offensive
 from shared.inputs import parse_nickname, parse_team
 from shared.db import update_players_conditionally
@@ -51,7 +51,7 @@ def lambda_handler(event, context, body, game):
             return response_payload(200, {"player_uuid": new_player.get("uuid")})
         
         logger.info(f"Join failed for '{nickname}' due to race condition.")
-        return error_payload(409, "The game state changed. Please try again.")
+        return conflict_payload()
 
     except Exception as err:
         return internal_error_payload(err)

--- a/api/play.py
+++ b/api/play.py
@@ -4,7 +4,7 @@ import os
 import boto3
 from botocore.exceptions import ClientError
 from itertools import combinations
-from shared.response import response_payload, error_payload, parameter_error_payload, internal_error_payload
+from shared.response import response_payload, error_payload, parameter_error_payload, conflict_payload, internal_error_payload
 from shared.db import table, RACE_LOST_ERROR_CODES
 from shared.constants import GameStatus, RuleValues
 from shared.logging import logger
@@ -271,13 +271,13 @@ def lambda_handler(event, context, body, game):
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
             game["move_deadline"] = start_player_timer(game)
             if not update_in_dynamodb(game["game_uuid"], game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"]):
-                return error_payload(409, "The game state changed.")
+                return conflict_payload()
             return response_payload(200, censor_game(game, player_nickname))
 
         else:
             end_round_state = handle_check(game)
             if not end_round_state:
-                return error_payload(409, "The game state changed.")
+                return conflict_payload()
             return response_payload(200, censor_game(end_round_state, player_nickname))
 
     except Exception as err:

--- a/api/remove_ais.py
+++ b/api/remove_ais.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, error_payload, internal_error_payload
+from shared.response import response_payload, conflict_payload, internal_error_payload
 from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards
@@ -20,7 +20,7 @@ def lambda_handler(event, context, body, game):
         max_cards = calculate_actual_max_cards(game.get("rules", {}), len(human_players))
 
         if not update_players_conditionally(game["game_uuid"], human_players, game["last_modified"], max_cards=max_cards):
-            return error_payload(409, "The game state changed. Please try again.")
+            return conflict_payload()
 
         return response_payload(200, {"message": "All AI players have been removed."})
 

--- a/api/remove_player.py
+++ b/api/remove_player.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.response import response_payload, parameter_error_payload, error_payload, conflict_payload, internal_error_payload
 from shared.db import update_players_conditionally
 from shared.constants import GameStatus
 from shared.game import calculate_actual_max_cards, get_player_by_nickname
@@ -44,7 +44,7 @@ def lambda_handler(event, context, body, game):
         max_cards = calculate_actual_max_cards(rules, len(new_players))
 
         if not update_players_conditionally(game["game_uuid"], new_players, game["last_modified"], admin_nickname=new_admin, max_cards=max_cards):
-            return error_payload(409, "The game state changed. Please try again.")
+            return conflict_payload()
 
         return response_payload(200, {"message": f"Player {target_nickname} removed successfully"})
 

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -1,25 +1,41 @@
 import time
 import decimal
+from botocore.exceptions import ClientError
 from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
-from shared.db import table
+from shared.db import table, RACE_LOST_ERROR_CODES
 from shared.constants import GameStatus
-from shared.game import update_n_cards, start_game, start_next_round, get_action_ids
+from shared.game import update_n_cards, start_game, start_next_round, find_losing_player_nickname
 from shared.decorators import validate_game_request
+from shared.logging import logger
 
-def update_player_readiness(game_uuid, player_index, ready_status):
+def update_player_readiness(game_uuid, player_index, player_uuid, ready_status):
     """
-    Atomically updates a single player's readiness and returns the full, updated game state.
+    Atomically updates a single player's readiness and returns the full, updated game
+    state, or None if the roster shifted under us. Guarded on the slot still holding the
+    player we resolved: a removal shifts every later index down, so an unguarded write
+    would land on somebody else.
     """
-    response = table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression=f"SET players[{player_index}].ready = :ready, last_modified = :last_modified",
-        ExpressionAttributeValues={
-            ':ready': ready_status,
-            ':last_modified': decimal.Decimal(str(time.time()))
-        },
-        ReturnValues="ALL_NEW"
-    )
-    return response.get('Attributes')
+    try:
+        response = table.update_item(
+            Key={'game_uuid': game_uuid},
+            UpdateExpression=f"SET players[{player_index}].ready = :ready, last_modified = :last_modified",
+            ConditionExpression=f"players[{player_index}].#uuid = :player_uuid",
+            ExpressionAttributeNames={'#uuid': "uuid"},
+            ExpressionAttributeValues={
+                ':ready': ready_status,
+                ':last_modified': decimal.Decimal(str(time.time())),
+                ':player_uuid': player_uuid
+            },
+            ReturnValues="ALL_NEW"
+        )
+        return response.get('Attributes')
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code in RACE_LOST_ERROR_CODES:
+            logger.warning(f"Readiness write for game {game_uuid} lost a race: {error_code}.")
+            return None
+        else:
+            raise
 
 @validate_game_request(require_player=True)
 def lambda_handler(event, context, body, game):
@@ -37,30 +53,33 @@ def lambda_handler(event, context, body, game):
         if len(players) < 2:
             return error_payload(403, "Cannot set readiness with only one player in the room.")
 
-        updated_game_state = update_player_readiness(game["game_uuid"], player_index, ready)
+        updated_game_state = update_player_readiness(game["game_uuid"], player_index, player_uuid, ready)
+        if not updated_game_state:
+            return error_payload(409, "The game state changed.")
 
         game_status = updated_game_state.get("status")
         if game_status == GameStatus.WAITING_FOR_READY:
-            action_ids = get_action_ids(updated_game_state.get("rules", {}))
-            losing_player_nickname = next((event.get("player") for event in reversed(updated_game_state.get("history", [])) if event.get("action_id") == action_ids["lose_round"]), None)
+            losing_player_nickname = find_losing_player_nickname(updated_game_state)
             temp_players = update_n_cards(updated_game_state, losing_player_nickname)
             active_players_for_next_round = [p for p in temp_players if p.get("n_cards", 0) > 0]
-            
+
+            # A start that loses its race leaves the game as it was; the readiness itself
+            # still landed, so report that and let the winning write drive the start.
             if len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round):
-                start_next_round(updated_game_state)
-                return response_payload(200, {"message": "All players ready. Next round started."})
-                
+                if start_next_round(updated_game_state):
+                    return response_payload(200, {"message": "All players ready. Next round started."})
+
         elif game_status == GameStatus.NOT_STARTED:
             updated_players = updated_game_state.get("players", [])
             all_ready = all(p.get("ready", False) for p in updated_players)
             has_enough_players = (len(updated_players) >= 2)
             non_null_teams = [t for t in [p.get("team") for p in updated_players] if t is not None]
             is_single_team = (len(non_null_teams) == len(updated_players) and len(set(non_null_teams)) == 1)
-            
+
             if all_ready and has_enough_players and not is_single_team:
-                start_game(updated_game_state)
-                return response_payload(200, {"message": "All players ready. Game started."})
-                
+                if start_game(updated_game_state):
+                    return response_payload(200, {"message": "All players ready. Game started."})
+
         return response_payload(200, {"message": "Readiness updated"})
 
     except Exception as err:

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -1,7 +1,7 @@
 import time
 import decimal
 from botocore.exceptions import ClientError
-from shared.response import response_payload, parameter_error_payload, error_payload, internal_error_payload
+from shared.response import response_payload, parameter_error_payload, error_payload, conflict_payload, internal_error_payload
 from shared.db import table, RACE_LOST_ERROR_CODES
 from shared.constants import GameStatus
 from shared.game import update_n_cards, start_game, start_next_round, find_losing_player_nickname
@@ -55,7 +55,7 @@ def lambda_handler(event, context, body, game):
 
         updated_game_state = update_player_readiness(game["game_uuid"], player_index, player_uuid, ready)
         if not updated_game_state:
-            return error_payload(409, "The game state changed.")
+            return conflict_payload()
 
         game_status = updated_game_state.get("status")
         if game_status == GameStatus.WAITING_FOR_READY:

--- a/api/shared/db.py
+++ b/api/shared/db.py
@@ -34,8 +34,9 @@ def save_in_dynamodb(obj, game_uuid=None, last_modified_condition=None):
         table.put_item(**put_params)
         return True
     except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            logger.warning(f"Conditional save failed for game_uuid: {obj.get('game_uuid')}.")
+        error_code = e.response['Error']['Code']
+        if last_modified_condition and error_code in RACE_LOST_ERROR_CODES: # Only a guarded save can lose a race
+            logger.warning(f"Conditional save failed for game_uuid: {obj.get('game_uuid')}: {error_code}.")
             return False
         else:
             raise
@@ -72,8 +73,9 @@ def update_players_conditionally(game_uuid, players, last_modified, **extra):
         table.update_item(**update_params)
         return True
     except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            logger.warning(f"Conditional players update failed for game_uuid: {game_uuid} due to a race condition.")
+        error_code = e.response['Error']['Code']
+        if error_code in RACE_LOST_ERROR_CODES:
+            logger.warning(f"Conditional players update failed for game_uuid: {game_uuid} due to a race condition: {error_code}.")
             return False
         else:
             raise

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -6,7 +6,8 @@ import time
 import decimal
 import copy
 import uuid
-from .db import table, save_in_dynamodb, transact_end_of_round
+from botocore.exceptions import ClientError
+from .db import table, save_in_dynamodb, transact_end_of_round, RACE_LOST_ERROR_CODES
 from .time_limit import send_time_limit_message
 from .logging import logger
 from .constants import GameStatus, CommonCardsRules, RuleValues, random_avatar
@@ -357,9 +358,14 @@ def resolve_opening_hands(players, rules, max_cards):
 
 
 def start_game(game):
+    """
+    Deals the opening hands and locks the roster in.
+    Guarded on last_modified. Returns True on success, False if the game changed under us.
+    """
     game_uuid = game["game_uuid"]
     players = game["players"]
     rules = game.get("rules", {})
+    original_last_modified = game["last_modified"]
 
     opening_hands = resolve_opening_hands(players, rules, game.get("max_cards", 0))
     for player in players:
@@ -377,32 +383,45 @@ def start_game(game):
     game['cp_nickname'] = cp_nickname
     move_deadline = start_player_timer(game)
 
-    table.update_item(
-        Key={'game_uuid': game_uuid},
-        UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
-        ExpressionAttributeValues={
-            ':last_modified': decimal.Decimal(str(time.time())),
-            ':players': players,
-            ':public': public,
-            ':status': status,
-            ':round_number': round_number,
-            ':hands': hands,
-            ':common_hand': common_hand,
-            ':cp_nickname': cp_nickname,
-            ':move_deadline': move_deadline
-        },
-        ExpressionAttributeNames={
-            '#game_public': "public",
-            '#game_status': "status"
-        }
-    )
-    return True
+    try:
+        table.update_item(
+            Key={'game_uuid': game_uuid},
+            UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
+            ConditionExpression="last_modified = :lm",
+            ExpressionAttributeValues={
+                ':last_modified': decimal.Decimal(str(time.time())),
+                ':players': players,
+                ':public': public,
+                ':status': status,
+                ':round_number': round_number,
+                ':hands': hands,
+                ':common_hand': common_hand,
+                ':cp_nickname': cp_nickname,
+                ':move_deadline': move_deadline,
+                ':lm': original_last_modified
+            },
+            ExpressionAttributeNames={
+                '#game_public': "public",
+                '#game_status': "status"
+            }
+        )
+        return True
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code in RACE_LOST_ERROR_CODES:
+            logger.warning(f"Start of game {game_uuid} lost a race: {error_code}.")
+            return False
+        else:
+            raise
 
 def start_next_round(game):
     """
     Recalls the loser of the previous round, updates cards,
     and starts the next round with the correct current player.
+    Guarded on last_modified. Returns True on success, False if the game changed under us.
     """
+    original_last_modified = game["last_modified"]
+
     # Update the card counts for the new round
     losing_player_nickname = find_losing_player_nickname(game)    
     losing_player = get_player_by_nickname(game["players"], losing_player_nickname)
@@ -424,9 +443,8 @@ def start_next_round(game):
     game["hands"], game["common_hand"] = draw_cards(game["players"], game.get("rules", {}))
     
     game["move_deadline"] = start_player_timer(game)
-    
-    save_in_dynamodb(game)
-    return True
+
+    return save_in_dynamodb(game, last_modified_condition=original_last_modified)
 
 def get_action_ids(rules):
     """
@@ -481,10 +499,10 @@ def end_round(game, losing_player_nickname):
     else:
         # No finish and no time limit: save archive state unconditionally and start the next round
         save_in_dynamodb(archive_state)
-        start_next_round(game)
-        return archive_state
+        if start_next_round(game):
+            return archive_state
 
-    return False # This is only reached if a transaction fails
+    return False # Only reached when a guarded write lost its race
 
 def unset_human_readiness(players):
     """

--- a/api/shared/response.py
+++ b/api/shared/response.py
@@ -55,6 +55,18 @@ def parameter_error_payload(param_key, param_value, message=None):
         body = f"{body}\n{message}"
     return error_payload(400, body)
 
+def conflict_payload():
+    """
+    Creates a 409 Conflict response for a write refused because the game changed
+    under it. Nothing was written, so the call is safe to repeat once the caller
+    has re-read the game.
+
+    The message is published API surface rather than an internal detail, so
+    clients may classify the error by matching it. Rephrasing it is a breaking
+    change; test_response.py pins the wording.
+    """
+    return error_payload(409, "The game state changed.")
+
 def nickname_rejected_payload(reason="profanity"):
     """
     Creates a 422 Unprocessable Content response for a syntactically valid

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -24,7 +24,8 @@ def lambda_handler(event, context, body, game):
         if int(game.get("rules", {}).get("time_limit", RuleValues.TIME_LIMIT_DEFAULT)) > RuleValues.TIME_LIMIT_NO_LIMIT:
             return error_payload(403, "Games with a time limit can only start when everyone is ready")
 
-        start_game(game)
+        if not start_game(game):
+            return error_payload(409, "The game state changed.")
 
         return response_payload(202, {"message": "Game started"})
 

--- a/api/start_game.py
+++ b/api/start_game.py
@@ -1,4 +1,4 @@
-from shared.response import response_payload, error_payload, internal_error_payload
+from shared.response import response_payload, error_payload, conflict_payload, internal_error_payload
 from shared.constants import GameStatus, RuleValues
 from shared.game import start_game
 from shared.decorators import validate_game_request
@@ -25,7 +25,7 @@ def lambda_handler(event, context, body, game):
             return error_payload(403, "Games with a time limit can only start when everyone is ready")
 
         if not start_game(game):
-            return error_payload(409, "The game state changed.")
+            return conflict_payload()
 
         return response_payload(202, {"message": "Game started"})
 

--- a/api/test/test_play.py
+++ b/api/test/test_play.py
@@ -1,0 +1,64 @@
+# Unit tests for play.update_in_dynamodb's error classification.
+# No network / AWS needed (the DynamoDB table is stubbed). Run from the api/ directory:
+#   python test/test_play.py
+import os
+import sys
+import decimal
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import play  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+
+
+class FakeTable:
+    def __init__(self, error_code=None):
+        self.error_code = error_code
+        self.calls = []
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error_code:
+            raise ClientError({'Error': {'Code': self.error_code}}, 'UpdateItem')
+
+
+class TestUpdateInDynamodb(unittest.TestCase):
+
+    def setUp(self):
+        self.real_table = play.table
+        self.args = ("uuid-1", "Bob", [{"player": "Alice", "action_id": 5}],
+                     decimal.Decimal("2000"), decimal.Decimal("1000"))
+
+    def tearDown(self):
+        play.table = self.real_table
+
+    def update(self):
+        return play.update_in_dynamodb(*self.args)
+
+    def test_success_returns_true_and_guards_on_last_modified(self):
+        play.table = fake = FakeTable()
+        self.assertTrue(self.update())
+        call = fake.calls[0]
+        self.assertEqual(call['ConditionExpression'], "last_modified = :lm")
+        self.assertEqual(call['ExpressionAttributeValues'][':lm'], decimal.Decimal("1000"))
+
+    def test_lost_condition_check_returns_false(self):
+        play.table = FakeTable(error_code='ConditionalCheckFailedException')
+        self.assertFalse(self.update())
+
+    def test_transaction_conflict_returns_false(self):
+        # A timeout ending the round runs transact_write_items; DynamoDB rejects
+        # singleton writes to the same item while that is in flight. The play
+        # lost the race, so it must not surface as a 500.
+        play.table = FakeTable(error_code='TransactionConflictException')
+        self.assertFalse(self.update())
+
+    def test_other_client_errors_propagate(self):
+        play.table = FakeTable(error_code='ProvisionedThroughputExceededException')
+        with self.assertRaises(ClientError):
+            self.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/test/test_readiness.py
+++ b/api/test/test_readiness.py
@@ -1,0 +1,156 @@
+# Unit tests for the readiness path's conditional writes.
+# No network / AWS needed (the DynamoDB table is stubbed). Run from the api/ directory:
+#   python test/test_readiness.py
+import os
+import sys
+import copy
+import decimal
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import set_readiness  # noqa: E402
+import shared.game as game_module  # noqa: E402
+import shared.decorators as decorators  # noqa: E402
+from shared.constants import GameStatus  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+
+GAME_UUID = "11111111-1111-1111-1111-111111111111"
+ADMIN_UUID = "22222222-2222-2222-2222-222222222222"
+BOB_UUID = "33333333-3333-3333-3333-333333333333"
+
+
+def player(uuid, nickname, ready=False, team=None):
+    return {"uuid": uuid, "nickname": nickname, "n_cards": 0, "ready": ready, "team": team}
+
+
+def lobby(players=None, **overrides):
+    game = {
+        "game_uuid": GAME_UUID,
+        "status": GameStatus.NOT_STARTED,
+        "admin_nickname": "Admin",
+        "max_cards": 5,
+        "rules": {},
+        "history": [],
+        "players": players if players is not None else [
+            player(ADMIN_UUID, "Admin"), player(BOB_UUID, "Bob")],
+        "last_modified": decimal.Decimal("1000"),
+    }
+    game.update(overrides)
+    return game
+
+
+class FakeTable:
+    """Records writes and fails the first `fail_times` of them with `error_code`."""
+
+    def __init__(self, error_code=None, fail_times=0):
+        self.error_code = error_code
+        self.fail_times = fail_times
+        self.calls = []
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error_code and len(self.calls) <= self.fail_times:
+            raise ClientError({'Error': {'Code': self.error_code}}, 'UpdateItem')
+        return {'Attributes': lobby()}
+
+
+class TestUpdatePlayerReadiness(unittest.TestCase):
+
+    def setUp(self):
+        self.real_table = set_readiness.table
+
+    def tearDown(self):
+        set_readiness.table = self.real_table
+
+    def write(self, index=1):
+        return set_readiness.update_player_readiness(GAME_UUID, index, BOB_UUID, True)
+
+    def test_write_is_guarded_on_the_uuid_in_that_slot(self):
+        set_readiness.table = fake = FakeTable()
+        self.assertIsNotNone(self.write())
+
+        call = fake.calls[0]
+        self.assertEqual(call['ConditionExpression'], "players[1].#uuid = :player_uuid")
+        self.assertEqual(call['ExpressionAttributeValues'][':player_uuid'], BOB_UUID)
+        # "uuid" is a DynamoDB reserved word, so the path has to go through a placeholder.
+        self.assertEqual(call['ExpressionAttributeNames']['#uuid'], "uuid")
+        self.assertIn("players[1].ready = :ready", call['UpdateExpression'])
+
+    def test_lost_race_returns_none(self):
+        set_readiness.table = FakeTable(error_code='ConditionalCheckFailedException', fail_times=1)
+        self.assertIsNone(self.write())
+
+    def test_transaction_conflict_returns_none(self):
+        set_readiness.table = FakeTable(error_code='TransactionConflictException', fail_times=1)
+        self.assertIsNone(self.write())
+
+    def test_other_client_errors_propagate(self):
+        set_readiness.table = FakeTable(error_code='ProvisionedThroughputExceededException', fail_times=1)
+        with self.assertRaises(ClientError):
+            self.write()
+
+
+class TestReadinessHandler(unittest.TestCase):
+    """A write the roster shifted under must be refused, not landed on whoever took the index."""
+
+    def setUp(self):
+        self.real_table = set_readiness.table
+        self.real_get = decorators.get_from_dynamodb
+        self.real_start = set_readiness.start_game
+        set_readiness.start_game = lambda game: True
+
+    def tearDown(self):
+        set_readiness.table = self.real_table
+        decorators.get_from_dynamodb = self.real_get
+        set_readiness.start_game = self.real_start
+
+    def call(self, game):
+        decorators.get_from_dynamodb = lambda _uuid: copy.deepcopy(game)
+        return set_readiness.lambda_handler(
+            {"pathParameters": {"game_uuid": GAME_UUID},
+             "queryStringParameters": {"player_uuid": BOB_UUID, "ready": "True"}}, None)
+
+    def test_happy_path_writes_once(self):
+        set_readiness.table = fake = FakeTable()
+        resp = self.call(lobby())
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual(len(fake.calls), 1)
+
+    def test_lost_race_reports_conflict(self):
+        # The roster shifted, so the write was refused rather than landing on the
+        # player who took the index. Repeating the call is the client's job.
+        set_readiness.table = fake = FakeTable(error_code='ConditionalCheckFailedException', fail_times=1)
+        resp = self.call(lobby())
+        self.assertEqual(resp["statusCode"], 409)
+        self.assertEqual(len(fake.calls), 1)
+
+class TestStartGameGuard(unittest.TestCase):
+    """Once the game is Running the roster is frozen, so an erased joiner has no way back."""
+
+    def setUp(self):
+        self.real_table = game_module.table
+
+    def tearDown(self):
+        game_module.table = self.real_table
+
+    def test_start_is_guarded_on_last_modified(self):
+        game_module.table = fake = FakeTable()
+        self.assertTrue(game_module.start_game(lobby()))
+
+        call = fake.calls[0]
+        self.assertEqual(call['ConditionExpression'], "last_modified = :lm")
+        self.assertEqual(call['ExpressionAttributeValues'][':lm'], decimal.Decimal("1000"))
+
+    def test_lost_race_returns_false(self):
+        game_module.table = FakeTable(error_code='ConditionalCheckFailedException', fail_times=1)
+        self.assertFalse(game_module.start_game(lobby()))
+
+    def test_other_client_errors_propagate(self):
+        game_module.table = FakeTable(error_code='ProvisionedThroughputExceededException', fail_times=1)
+        with self.assertRaises(ClientError):
+            game_module.start_game(lobby())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/test/test_response.py
+++ b/api/test/test_response.py
@@ -1,0 +1,37 @@
+# Unit tests for response payloads whose exact shape is API surface.
+# No network / AWS needed. Run from the api/ directory:
+#   python test/test_response.py
+import os
+import sys
+import json
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from shared.response import conflict_payload, nickname_rejected_payload  # noqa: E402
+
+
+class TestConflictPayload(unittest.TestCase):
+
+    def setUp(self):
+        self.payload = conflict_payload()
+        self.body = json.loads(self.payload["body"])
+
+    def test_status_is_409(self):
+        self.assertEqual(self.payload["statusCode"], 409)
+
+    def test_message_is_stable(self):
+        # Published wording, matchable by clients: a failure here means an API
+        # change, not a stale test. Reword only with a deliberate release.
+        self.assertEqual(self.body["error"], "The game state changed.")
+
+
+class TestNicknameRejectedPayload(unittest.TestCase):
+
+    def test_carries_a_machine_readable_reason(self):
+        body = json.loads(nickname_rejected_payload()["body"])
+        self.assertEqual(body["reason"], "profanity")
+        self.assertEqual(body["field"], "nickname")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #241.

ee17e67391569bcbdc394129e693ce4b040939b8 is motivated by the iOS client matching the exact error strings coming from the API. Going forward, we should reduce reliance on those and try to only use the codes