### PR TITLE
Remove wasteful get_function call from aiagent-orchestrator

### DIFF
--- a/api/aiagent-orchestrator.py
+++ b/api/aiagent-orchestrator.py
@@ -19,14 +19,6 @@ def name_valid(name):
     return name and isinstance(name, str) and pattern.match(name)
 
 
-def lambda_function_exists(name):
-    try:
-        response = lambda_client.get_function(FunctionName=name)
-    except lambda_client.exceptions.ResourceNotFoundException:
-        return False
-    return response.get("ResponseMetadata").get("HTTPStatusCode") == 200
-
-
 def call_aiagent(payload):
     """
         Invoke blef-aiagent-[...] asynchronously
@@ -34,13 +26,18 @@ def call_aiagent(payload):
     agent_name = get_aiagent_name(payload)
     logger.info("## AGENT_NAME")
     logger.info(agent_name)
+    if not name_valid(agent_name):
+        logger.error(f"## REFUSING TO INVOKE AN AGENT WITH AN UNUSABLE NAME: {agent_name}")
+        return
     function_name = f'blef-aiagent-{agent_name}'
-    if name_valid(agent_name) and lambda_function_exists(function_name):
+    try:
         return lambda_client.invoke(
             FunctionName=function_name,
             InvocationType='Event',
             Payload=json.dumps(payload)
             )
+    except lambda_client.exceptions.ResourceNotFoundException:
+        logger.error(f"## NO SUCH AI AGENT FUNCTION: {function_name}")
 
 
 def get_game(record):


### PR DESCRIPTION
Invoke rejects an unknown function by itself, so a missing agent will be reported on the path where it actually happens rather than by looking the function up before every move. `name_valid` will still guard what goes into the name.

`aiagent-orchestrator` is very slow right now and this is the likely culprit. This change might save a few percent of overall cost and latency of the service