### PR TITLE
Delete dead WebSocket connections

### DIFF
--- a/api/shared/websocket.py
+++ b/api/shared/websocket.py
@@ -1,0 +1,35 @@
+import os
+import json
+import boto3
+from .response import response_payload, DecimalEncoder
+from .db import websocket_table
+from .logging import logger
+
+watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
+watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
+
+# Derived from the API id rather than looked up - fewer permissions, smaller control-plane throttling risk, slightly faster
+endpoint_url = f"https://{watch_game_websocket_api_id}.execute-api.{os.environ['AWS_REGION']}.amazonaws.com/{watch_game_websocket_api_stage}"
+apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
+
+# Upper bound on concurrent websocket posts per broadcast
+MAX_BROADCAST_WORKERS = 16
+
+
+def post_to_connection(payload, connection_id):
+    """
+    Sends a payload to a single websocket connection.
+    Dropped connections are forgotten.
+    """
+    try:
+        apigateway.post_to_connection(
+            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
+            ConnectionId=connection_id
+        )
+    except apigateway.exceptions.GoneException:
+        websocket_table.delete_item(Key={'connection_id': connection_id})
+    except Exception as err:
+        # A single failure must not abort the rest of the broadcast.
+        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
+        logger.info(str(err))
+    return True

--- a/api/watch-chat.py
+++ b/api/watch-chat.py
@@ -1,37 +1,10 @@
-import os
-import boto3
 from boto3.dynamodb.conditions import Key
 from concurrent.futures import ThreadPoolExecutor
 import json
-from shared.response import *
 from shared.api_gateway import parse_event
 from shared.logging import logger
 from shared.db import websocket_table, get_from_dynamodb
-
-
-watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
-watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
-
-endpoint_url = f"{boto3.client('apigatewayv2').get_api(ApiId=watch_game_websocket_api_id).get('ApiEndpoint')}/{watch_game_websocket_api_stage}".replace("wss://", "https://")
-apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
-
-# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
-# network-bound, so threads parallelise well despite the GIL.
-MAX_BROADCAST_WORKERS = 16
-
-def post_to_connection(payload, connection_id):
-    logger.info('## POSTING TO CONNECTION')
-    logger.info(connection_id)
-    try:
-        apigateway.post_to_connection(
-            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
-            ConnectionId=connection_id
-        )
-    except Exception as err:
-        # A single stale/gone connection must not abort the rest of the broadcast.
-        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
-        logger.info(str(err))
-    return True
+from shared.websocket import post_to_connection, MAX_BROADCAST_WORKERS
 
 
 def broadcast_reaction(reaction_details):

--- a/api/watch-game-connect.py
+++ b/api/watch-game-connect.py
@@ -9,6 +9,9 @@ from shared.logging import logger
 from shared.db import table as games_table, websocket_table
 
 
+CONNECTION_RETENTION_PERIOD_SECONDS = 3 * 60 * 60  # API Gateway's WebSocket connections can only last two hours anyway
+
+
 def get_game(game_uuid):
     response = games_table.query(KeyConditionExpression=Key('game_uuid').eq(game_uuid))
     items = response.get("Items")
@@ -18,7 +21,9 @@ def get_game(game_uuid):
 
 
 def save_connection_object(obj):
-    obj["last_modified"] = decimal.Decimal(str(time.time()))
+    now = time.time()
+    obj["last_modified"] = decimal.Decimal(str(now))
+    obj["ttl"] = int(now + CONNECTION_RETENTION_PERIOD_SECONDS)
     websocket_table.put_item(Item=obj)
     return True
 

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -9,23 +9,14 @@ from shared.api_gateway import parse_event
 from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, is_update_redundant
 from shared.logging import logger
 from shared.db import websocket_table
+from shared.websocket import post_to_connection, MAX_BROADCAST_WORKERS
 
 sqs_client = boto3.client("sqs")
 AIAGENT_QUEUE_NAME = os.environ.get("aiagent_queue_name")
 
-# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
-# network-bound, so threads parallelise well despite the GIL.
-MAX_BROADCAST_WORKERS = 16
-
 # Cached lazily on first use so the queue URL is resolved once per container
 # (and captured by the SnapStart snapshot) instead of on every broadcast.
 _aiagent_queue_url = None
-
-watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
-watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
-
-endpoint_url = f"{boto3.client('apigatewayv2').get_api(ApiId=watch_game_websocket_api_id).get('ApiEndpoint')}/{watch_game_websocket_api_stage}".replace("wss://", "https://")
-apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
 
 deserializer = boto3.dynamodb.types.TypeDeserializer()
 
@@ -96,20 +87,6 @@ def find_connected_public_games_watchers():
         IndexName="game_uuid-index"
     )
     return [(connection["connection_id"]) for connection in response.get("Items")]
-
-
-def post_to_connection(payload, connection_id):
-    logger.info('## POSTING TO CONNECTION')
-    logger.info(connection_id)
-    try:
-        response = apigateway.post_to_connection(
-            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
-            ConnectionId=connection_id
-        )
-    except Exception as err:
-        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
-        logger.info(str(err))
-    return True
 
 
 def deserialise_dynamodb_stream_event(obj):

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -70,5 +70,16 @@ concurrently through a bounded, throttle-safe worker pool (see the script header
 Reports are reviewed by the maintainers pulling straight from DynamoDB. `deployment/fetch_reports.py` scans the table, prints reports that arrived since its last run, and flags reported nicknames that pass the current profanity filter (blocklist candidates).
 
 
+### Websocket connection expiry (one-time setup)
+
+`watch_game_websocket_manager` needs TTL enabled on the `ttl` attribute:
+
+```bash
+aws dynamodb update-time-to-live --table-name watch_game_websocket_manager \
+  --time-to-live-specification "Enabled=true, AttributeName=ttl"
+```
+
+This is only a backstop. When a broadcast is refused because of a dropped connection, the connection is deleted from the table by a separate mechanism.
+
 ### Architecture overview
 ![Blef architecture](https://user-images.githubusercontent.com/10632991/146104548-3e4693ab-4889-43c2-b7a0-e4d47d52fb36.png)


### PR DESCRIPTION
We currently have thousands of dead connections in the `watch_game_websocket_manager` table. That's because dropped connections are not guaranteed to be deleted. So now:
* There's a TTL mechanism that ensures connections are deleted after 3 hours. API Gateway terminates them within 2 hours anyway, so 3 hours has no impact on users
* Connections that are discovered to have been dropped (GoneException) when the `watch-game-stream` Lambda or the `watch-chat` Lambda is trying to broadcast to them are deleted

Additionally, the `endpoint_url` variable was refactored to not depend on `get_api`. This reduces permissions, throttling risks and should even make cold starts slightly faster.

After the PR is merged and deployed, TTL needs setting up (the command is in the deployment README change) and existing dead connections without TTL can be summarily deleted