### PR TITLE
Fix the DynamoDB stream lag

### DIFF
--- a/api/play.py
+++ b/api/play.py
@@ -235,9 +235,12 @@ def handle_check(game):
 
 
 def push_to_other_players(game, mover_uuid):
-    """Sends the new state straight to other watchers."""
-    humans = [p for p in game.get("players", []) if not p.get("ai_agent")]
-    if len(humans) < 2:
+    """Sends the new state straight to other watchers after a human move in a multiplayer game."""
+    players = game.get("players", [])
+    mover = next((p for p in players if p.get("uuid") == mover_uuid), None)
+    if mover is None or mover.get("ai_agent"):
+        return
+    if len([p for p in players if not p.get("ai_agent")]) < 2:
         return
     broadcast_game_state(game, exclude_player_uuid=mover_uuid)
 

--- a/api/play.py
+++ b/api/play.py
@@ -10,6 +10,7 @@ from shared.constants import GameStatus, RuleValues
 from shared.logging import logger
 from shared.game import censor_game, find_next_active_player, end_round, start_player_timer, get_action_ids
 from shared.decorators import validate_game_request
+from shared.websocket import broadcast_game_state
 
 sqs_client = boto3.client("sqs")
 TIME_LIMIT_QUEUE_NAME = os.environ.get("time_limit_queue_name")
@@ -176,7 +177,7 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
         print(f"Error in determine_set_existence: {err}")
         return False
 
-def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modified):
+def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modified, written_at):
     """
     Conditionally updates the game state in DynamoDB.
     Returns True on success, False on failure (due to race condition).
@@ -187,7 +188,7 @@ def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modi
             UpdateExpression="SET last_modified = :t, cp_nickname = :c, history = :h, move_deadline = :d",
             ConditionExpression="last_modified = :lm",
             ExpressionAttributeValues={
-                ':t': decimal.Decimal(str(time.time())),
+                ':t': written_at,
                 ':c': cp_nickname,
                 ':h': history,
                 ':d': move_deadline,
@@ -232,6 +233,14 @@ def handle_check(game):
 
     return end_round(game, losing_player_nickname)
 
+
+def push_to_other_players(game, mover_uuid):
+    """Sends the new state straight to other watchers."""
+    humans = [p for p in game.get("players", []) if not p.get("ai_agent")]
+    if len(humans) < 2:
+        return
+    broadcast_game_state(game, exclude_player_uuid=mover_uuid)
+
 @validate_game_request(
     require_player=True, 
     required_status=GameStatus.RUNNING, 
@@ -241,6 +250,7 @@ def lambda_handler(event, context, body, game):
     try:
         # Check if it's actually this player's turn
         player_nickname = body["player_nickname"]
+        player_uuid = str(body.get("player_uuid"))
         if player_nickname != game["cp_nickname"]:
             return parameter_error_payload("player_uuid", body.get("player_uuid"), "Not your turn or invalid player UUID")
 
@@ -270,14 +280,18 @@ def lambda_handler(event, context, body, game):
         if action_id != check_action:
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
             game["move_deadline"] = start_player_timer(game)
-            if not update_in_dynamodb(game["game_uuid"], game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"]):
+            written_at = decimal.Decimal(str(time.time()))
+            if not update_in_dynamodb(game["game_uuid"], game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"], written_at):
                 return conflict_payload()
+            game["last_modified"] = written_at
+            push_to_other_players(game, player_uuid)
             return response_payload(200, censor_game(game, player_nickname))
 
         else:
             end_round_state = handle_check(game)
             if not end_round_state:
                 return conflict_payload()
+            push_to_other_players(end_round_state, player_uuid)
             return response_payload(200, censor_game(end_round_state, player_nickname))
 
     except Exception as err:

--- a/api/play.py
+++ b/api/play.py
@@ -177,11 +177,12 @@ def determine_set_existence(all_cards, action_id, rules, num_jokers):
         print(f"Error in determine_set_existence: {err}")
         return False
 
-def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modified, written_at):
+def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modified):
     """
     Conditionally updates the game state in DynamoDB.
-    Returns True on success, False on failure (due to race condition).
+    Returns the last_modified it wrote, or None if it lost a race.
     """
+    written_at = decimal.Decimal(str(time.time()))
     try:
         table.update_item(
             Key={'game_uuid': game_uuid},
@@ -195,12 +196,12 @@ def update_in_dynamodb(game_uuid, cp_nickname, history, move_deadline, last_modi
                 ':lm': last_modified
             }
         )
-        return True
+        return written_at
     except ClientError as e:
         error_code = e.response['Error']['Code']
         if error_code in RACE_LOST_ERROR_CODES:
             logger.warning(f"Failed to update game state for {game_uuid} due to a race condition (play vs timeout): {error_code}.")
-            return False
+            return None
         else:
             raise
 
@@ -234,15 +235,14 @@ def handle_check(game):
     return end_round(game, losing_player_nickname)
 
 
-def push_to_other_players(game, mover_uuid):
-    """Sends the new state straight to other watchers after a human move in a multiplayer game."""
-    players = game.get("players", [])
-    mover = next((p for p in players if p.get("uuid") == mover_uuid), None)
+def broadcast_human_move(game, mover_uuid):
+    """
+    Sends the new state to every watcher, including the mover, after a human move.
+    """
+    mover = next((p for p in game.get("players", []) if p.get("uuid") == mover_uuid), None)
     if mover is None or mover.get("ai_agent"):
         return
-    if len([p for p in players if not p.get("ai_agent")]) < 2:
-        return
-    broadcast_game_state(game, exclude_player_uuid=mover_uuid)
+    broadcast_game_state(game)
 
 @validate_game_request(
     require_player=True, 
@@ -283,18 +283,18 @@ def lambda_handler(event, context, body, game):
         if action_id != check_action:
             game["cp_nickname"] = find_next_active_player(game["players"], game["cp_nickname"])["nickname"]
             game["move_deadline"] = start_player_timer(game)
-            written_at = decimal.Decimal(str(time.time()))
-            if not update_in_dynamodb(game["game_uuid"], game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"], written_at):
+            written_at = update_in_dynamodb(game["game_uuid"], game["cp_nickname"], game["history"], game["move_deadline"], game["last_modified"])
+            if not written_at:
                 return conflict_payload()
             game["last_modified"] = written_at
-            push_to_other_players(game, player_uuid)
+            broadcast_human_move(game, player_uuid)
             return response_payload(200, censor_game(game, player_nickname))
 
         else:
             end_round_state = handle_check(game)
             if not end_round_state:
                 return conflict_payload()
-            push_to_other_players(end_round_state, player_uuid)
+            broadcast_human_move(end_round_state, player_uuid)
             return response_payload(200, censor_game(end_round_state, player_nickname))
 
     except Exception as err:

--- a/api/set_readiness.py
+++ b/api/set_readiness.py
@@ -6,6 +6,7 @@ from shared.db import table, RACE_LOST_ERROR_CODES
 from shared.constants import GameStatus
 from shared.game import update_n_cards, start_game, start_next_round, find_losing_player_nickname
 from shared.decorators import validate_game_request
+from shared.websocket import broadcast_game_state
 from shared.logging import logger
 
 def update_player_readiness(game_uuid, player_index, player_uuid, ready_status):
@@ -67,6 +68,7 @@ def lambda_handler(event, context, body, game):
             # still landed, so report that and let the winning write drive the start.
             if len(active_players_for_next_round) >= 2 and all(p.get("ready") for p in active_players_for_next_round):
                 if start_next_round(updated_game_state):
+                    broadcast_game_state(updated_game_state)
                     return response_payload(200, {"message": "All players ready. Next round started."})
 
         elif game_status == GameStatus.NOT_STARTED:
@@ -78,8 +80,10 @@ def lambda_handler(event, context, body, game):
 
             if all_ready and has_enough_players and not is_single_team:
                 if start_game(updated_game_state):
+                    broadcast_game_state(updated_game_state)
                     return response_payload(200, {"message": "All players ready. Game started."})
 
+        broadcast_game_state(updated_game_state)
         return response_payload(200, {"message": "Readiness updated"})
 
     except Exception as err:

--- a/api/shared/game.py
+++ b/api/shared/game.py
@@ -382,6 +382,7 @@ def start_game(game):
     game['round_number'] = round_number
     game['cp_nickname'] = cp_nickname
     move_deadline = start_player_timer(game)
+    written_at = decimal.Decimal(str(time.time()))
 
     try:
         table.update_item(
@@ -389,7 +390,7 @@ def start_game(game):
             UpdateExpression="set last_modified = :last_modified, players = :players, #game_public = :public, #game_status = :status, round_number = :round_number, hands = :hands, common_hand = :common_hand, cp_nickname = :cp_nickname, move_deadline = :move_deadline",
             ConditionExpression="last_modified = :lm",
             ExpressionAttributeValues={
-                ':last_modified': decimal.Decimal(str(time.time())),
+                ':last_modified': written_at,
                 ':players': players,
                 ':public': public,
                 ':status': status,
@@ -405,6 +406,16 @@ def start_game(game):
                 '#game_status': "status"
             }
         )
+        # Leave the caller holding what was actually persisted, so it can be broadcast.
+        game.update({
+            'players': players,
+            'public': public,
+            'status': status,
+            'hands': hands,
+            'common_hand': common_hand,
+            'move_deadline': move_deadline,
+            'last_modified': written_at
+        })
         return True
     except ClientError as e:
         error_code = e.response['Error']['Code']

--- a/api/shared/websocket.py
+++ b/api/shared/websocket.py
@@ -47,14 +47,11 @@ def find_connected_connections(game_uuid):
     return [(c["connection_id"], c.get("player_uuid")) for c in response.get("Items", [])]
 
 
-def broadcast_game_state(game, exclude_player_uuid=None):
+def broadcast_game_state(game):
     """
     Pushes a game state to everyone watching it, censored per recipient.
-    `exclude_player_uuid` skips one player, in case the caller returns state to them in the HTTP response
     """
-    recipients = [(connection_id, player_uuid)
-                  for connection_id, player_uuid in find_connected_connections(game["game_uuid"])
-                  if exclude_player_uuid is None or player_uuid != exclude_player_uuid]
+    recipients = find_connected_connections(game["game_uuid"])
     if not recipients:
         return
 

--- a/api/shared/websocket.py
+++ b/api/shared/websocket.py
@@ -1,0 +1,35 @@
+import os
+import json
+import boto3
+from .response import response_payload, DecimalEncoder
+from .db import websocket_table
+from .logging import logger
+
+watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
+watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
+
+# Derived from the API id rather than looked up - fewer permissions, smaller control-plane throttling risk, slightly faster
+endpoint_url = f"https://{watch_game_websocket_api_id}.execute-api.{os.environ['AWS_REGION']}.amazonaws.com/{watch_game_websocket_api_stage}"
+apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
+
+# Upper bound on concurrent websocket posts per broadcast
+MAX_BROADCAST_WORKERS = 16
+
+
+def post_to_connection(payload, connection_id):
+    """
+    Sends a payload to a single websocket connection.
+    Dropped connections are forgotten.
+    """
+    try:
+        apigateway.post_to_connection(
+            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
+            ConnectionId=connection_id
+        )
+    except apigateway.exceptions.GoneException:
+        websocket_table.delete_item(Key={'connection_id': connection_id})
+    except Exception as err:
+        # A single failure must not abort the rest of the broadcast.
+        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
+        logger.info(str(err))
+    return True

--- a/api/shared/websocket.py
+++ b/api/shared/websocket.py
@@ -1,8 +1,11 @@
 import os
 import json
 import boto3
+from boto3.dynamodb.conditions import Key
+from concurrent.futures import ThreadPoolExecutor
 from .response import response_payload, DecimalEncoder
 from .db import websocket_table
+from .game import censor_game, get_nickname_by_uuid
 from .logging import logger
 
 watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
@@ -33,3 +36,32 @@ def post_to_connection(payload, connection_id):
         logger.info('## ERROR: COULD NOT POST TO CONNECTION')
         logger.info(str(err))
     return True
+
+
+def find_connected_connections(game_uuid):
+    """Connections watching a game. Round snapshots have the round suffix stripped to get the game UUID."""
+    response = websocket_table.query(
+        KeyConditionExpression=Key('game_uuid').eq(game_uuid.split("_")[0]),
+        IndexName="game_uuid-index"
+    )
+    return [(c["connection_id"], c.get("player_uuid")) for c in response.get("Items", [])]
+
+
+def broadcast_game_state(game, exclude_player_uuid=None):
+    """
+    Pushes a game state to everyone watching it, censored per recipient.
+    `exclude_player_uuid` skips one player, in case the caller returns state to them in the HTTP response
+    """
+    recipients = [(connection_id, player_uuid)
+                  for connection_id, player_uuid in find_connected_connections(game["game_uuid"])
+                  if exclude_player_uuid is None or player_uuid != exclude_player_uuid]
+    if not recipients:
+        return
+
+    def push(recipient):
+        connection_id, player_uuid = recipient
+        nickname = get_nickname_by_uuid(game.get("players", []), player_uuid)
+        post_to_connection(censor_game(game, nickname), connection_id)
+
+    with ThreadPoolExecutor(max_workers=min(len(recipients), MAX_BROADCAST_WORKERS)) as executor:
+        list(executor.map(push, recipients))

--- a/api/test/test_aiagent_orchestrator.py
+++ b/api/test/test_aiagent_orchestrator.py
@@ -1,0 +1,103 @@
+# Unit tests for the AI agent orchestrator's routing.
+# No network / AWS needed (the Lambda client is stubbed). Run from the api/ directory:
+#   python test/test_aiagent_orchestrator.py
+import os
+import sys
+import importlib
+import json
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+orchestrator = importlib.import_module("aiagent-orchestrator")  # noqa: E402
+
+
+class ResourceNotFoundException(Exception):
+    pass
+
+
+class FakeLambdaClient:
+    """Records invocations, optionally failing them the way Invoke reports a missing function."""
+
+    exceptions = type("Exceptions", (), {"ResourceNotFoundException": ResourceNotFoundException})
+
+    def __init__(self, missing=False):
+        self.missing = missing
+        self.calls = []
+
+    def invoke(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.missing:
+            raise ResourceNotFoundException("Function not found")
+        return {"StatusCode": 202}
+
+    def get_function(self, **kwargs):
+        raise AssertionError("The orchestrator must not look the function up before invoking it")
+
+
+def game(agent="conservative", nickname="Dazhbog_(AI)"):
+    return {
+        "game_uuid": "11111111-1111-1111-1111-111111111111",
+        "cp_nickname": nickname,
+        "players": [{"uuid": "u1", "nickname": nickname, "ai_agent": agent}],
+    }
+
+
+class TestCallAiagent(unittest.TestCase):
+
+    def setUp(self):
+        self.real_client = orchestrator.lambda_client
+
+    def tearDown(self):
+        orchestrator.lambda_client = self.real_client
+
+    def test_invokes_the_matching_agent_asynchronously(self):
+        orchestrator.lambda_client = fake = FakeLambdaClient()
+        orchestrator.call_aiagent(game())
+
+        self.assertEqual(len(fake.calls), 1)
+        call = fake.calls[0]
+        self.assertEqual(call["FunctionName"], "blef-aiagent-conservative")
+        self.assertEqual(call["InvocationType"], "Event")
+        self.assertEqual(json.loads(call["Payload"])["cp_nickname"], "Dazhbog_(AI)")
+
+    def test_missing_function_is_swallowed_not_raised(self):
+        # A missing agent must not fail the whole SQS batch.
+        orchestrator.lambda_client = FakeLambdaClient(missing=True)
+        self.assertIsNone(orchestrator.call_aiagent(game()))
+
+    def test_unusable_agent_name_is_never_interpolated(self):
+        orchestrator.lambda_client = fake = FakeLambdaClient()
+        for bad in ["../../etc", "has space", "semi;colon", "", None]:
+            orchestrator.call_aiagent(game(agent=bad))
+        self.assertEqual(fake.calls, [])
+
+
+class TestHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.real_client = orchestrator.lambda_client
+
+    def tearDown(self):
+        orchestrator.lambda_client = self.real_client
+
+    def test_processes_every_record_in_the_batch(self):
+        orchestrator.lambda_client = fake = FakeLambdaClient()
+        event = {"Records": [{"body": json.dumps(game())}, {"body": json.dumps(game(agent="nfsp"))}]}
+
+        resp = orchestrator.lambda_handler(event, None)
+
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual([c["FunctionName"] for c in fake.calls],
+                         ["blef-aiagent-conservative", "blef-aiagent-nfsp"])
+
+    def test_unparseable_record_is_skipped(self):
+        orchestrator.lambda_client = fake = FakeLambdaClient()
+        resp = orchestrator.lambda_handler({"Records": [{"body": "not json"}, {}]}, None)
+
+        self.assertEqual(resp["statusCode"], 200)
+        self.assertEqual(fake.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/test/test_broadcast.py
+++ b/api/test/test_broadcast.py
@@ -1,0 +1,114 @@
+# Unit tests for shared.websocket.broadcast_game_state.
+# No network / AWS needed (the management API and the table are stubbed). Run from
+# the api/ directory:
+#   python test/test_broadcast.py
+import os
+import sys
+import json
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+os.environ.setdefault("AWS_REGION", "eu-west-2")
+os.environ.setdefault("watch_game_websocket_api_id", "abc123")
+os.environ.setdefault("watch_game_websocket_api_stage", "production")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import shared.websocket as ws  # noqa: E402
+
+GAME_UUID = "11111111-1111-1111-1111-111111111111"
+ALICE, BOB = "aaaa-1", "bbbb-2"
+
+
+class FakeApiGateway:
+    exceptions = type("Exceptions", (), {"GoneException": type("GoneException", (Exception,), {})})
+
+    def __init__(self):
+        self.sent = []
+
+    def post_to_connection(self, **kwargs):
+        self.sent.append((kwargs["ConnectionId"], json.loads(json.loads(kwargs["Data"])["body"])))
+
+
+class FakeTable:
+    def __init__(self, items):
+        self.items = items
+        self.queries = []
+
+    def query(self, **kwargs):
+        self.queries.append(kwargs)
+        return {"Items": self.items}
+
+
+def game(players=None):
+    return {
+        "game_uuid": GAME_UUID,
+        "admin_nickname": "Alice", "public": "false", "room": 1, "status": "Running",
+        "round_number": 1, "max_cards": 5, "rules": {}, "history": [], "common_hand": [],
+        "cp_nickname": "Alice", "last_modified": 1000.0, "move_deadline": None,
+        "players": players or [
+            {"uuid": ALICE, "nickname": "Alice", "n_cards": 1},
+            {"uuid": BOB, "nickname": "Bob", "n_cards": 1},
+        ],
+        "hands": [{"nickname": "Alice", "hand": [{"value": 1, "colour": 1}]},
+                  {"nickname": "Bob", "hand": [{"value": 2, "colour": 2}]}],
+    }
+
+
+class TestBroadcastGameState(unittest.TestCase):
+
+    def setUp(self):
+        self.real_api, self.real_table = ws.apigateway, ws.websocket_table
+        ws.apigateway = self.api = FakeApiGateway()
+
+    def tearDown(self):
+        ws.apigateway, ws.websocket_table = self.real_api, self.real_table
+
+    def connections(self, *pairs):
+        ws.websocket_table = self.table = FakeTable(
+            [{"connection_id": c, "player_uuid": p} for c, p in pairs])
+
+    def test_reaches_every_watcher(self):
+        self.connections(("c1", ALICE), ("c2", BOB))
+        ws.broadcast_game_state(game())
+        self.assertEqual({c for c, _ in self.api.sent}, {"c1", "c2"})
+
+    def test_excluded_player_is_skipped(self):
+        self.connections(("c1", ALICE), ("c2", BOB))
+        ws.broadcast_game_state(game(), exclude_player_uuid=ALICE)
+        self.assertEqual([c for c, _ in self.api.sent], ["c2"])
+
+    def test_each_recipient_sees_only_their_own_hand(self):
+        # The whole state passes through here, so a censoring slip would leak cards.
+        self.connections(("c1", ALICE), ("c2", BOB))
+        ws.broadcast_game_state(game())
+        by_conn = dict(self.api.sent)
+        self.assertEqual([h["nickname"] for h in by_conn["c1"]["hands"]], ["Alice"])
+        self.assertEqual([h["nickname"] for h in by_conn["c2"]["hands"]], ["Bob"])
+
+    def test_observers_without_a_player_uuid_still_get_it(self):
+        self.connections(("c1", None))
+        ws.broadcast_game_state(game())
+        self.assertEqual(len(self.api.sent), 1)
+        self.assertEqual(self.api.sent[0][1]["hands"], [])
+
+    def test_round_snapshots_are_watched_through_the_live_game(self):
+        self.connections(("c1", ALICE))
+        snapshot = game()
+        snapshot["game_uuid"] = f"{GAME_UUID}_4"
+        ws.broadcast_game_state(snapshot)
+        self.assertEqual(self.table.queries[0]["IndexName"], "game_uuid-index")
+        queried = self.table.queries[0]["KeyConditionExpression"].get_expression()["values"][1]
+        self.assertEqual(queried, GAME_UUID)
+
+    def test_nobody_connected_sends_nothing(self):
+        self.connections()
+        ws.broadcast_game_state(game())
+        self.assertEqual(self.api.sent, [])
+
+    def test_excluding_the_only_watcher_sends_nothing(self):
+        self.connections(("c1", ALICE))
+        ws.broadcast_game_state(game(), exclude_player_uuid=ALICE)
+        self.assertEqual(self.api.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/test/test_broadcast.py
+++ b/api/test/test_broadcast.py
@@ -71,10 +71,10 @@ class TestBroadcastGameState(unittest.TestCase):
         ws.broadcast_game_state(game())
         self.assertEqual({c for c, _ in self.api.sent}, {"c1", "c2"})
 
-    def test_excluded_player_is_skipped(self):
+    def test_the_mover_is_not_skipped(self):
         self.connections(("c1", ALICE), ("c2", BOB))
-        ws.broadcast_game_state(game(), exclude_player_uuid=ALICE)
-        self.assertEqual([c for c, _ in self.api.sent], ["c2"])
+        ws.broadcast_game_state(game())
+        self.assertEqual(sorted(c for c, _ in self.api.sent), ["c1", "c2"])
 
     def test_each_recipient_sees_only_their_own_hand(self):
         # The whole state passes through here, so a censoring slip would leak cards.
@@ -104,10 +104,10 @@ class TestBroadcastGameState(unittest.TestCase):
         ws.broadcast_game_state(game())
         self.assertEqual(self.api.sent, [])
 
-    def test_excluding_the_only_watcher_sends_nothing(self):
+    def test_a_lone_watcher_still_gets_it(self):
         self.connections(("c1", ALICE))
-        ws.broadcast_game_state(game(), exclude_player_uuid=ALICE)
-        self.assertEqual(self.api.sent, [])
+        ws.broadcast_game_state(game())
+        self.assertEqual(len(self.api.sent), 1)
 
 
 if __name__ == "__main__":

--- a/api/test/test_play.py
+++ b/api/test/test_play.py
@@ -1,4 +1,4 @@
-# Unit tests for play.update_in_dynamodb's error classification.
+# Unit tests for play's conditional write and its direct websocket push.
 # No network / AWS needed (the DynamoDB table is stubbed). Run from the api/ directory:
 #   python test/test_play.py
 import os
@@ -7,6 +7,10 @@ import decimal
 import unittest
 
 os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+# play broadcasts, so it pulls in shared.websocket's endpoint construction
+os.environ.setdefault("AWS_REGION", "eu-west-2")
+os.environ.setdefault("watch_game_websocket_api_id", "abc123")
+os.environ.setdefault("watch_game_websocket_api_stage", "production")
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import play  # noqa: E402
 from botocore.exceptions import ClientError  # noqa: E402
@@ -28,7 +32,7 @@ class TestUpdateInDynamodb(unittest.TestCase):
     def setUp(self):
         self.real_table = play.table
         self.args = ("uuid-1", "Bob", [{"player": "Alice", "action_id": 5}],
-                     decimal.Decimal("2000"), decimal.Decimal("1000"))
+                     decimal.Decimal("2000"), decimal.Decimal("1000"), decimal.Decimal("3000"))
 
     def tearDown(self):
         play.table = self.real_table
@@ -42,6 +46,9 @@ class TestUpdateInDynamodb(unittest.TestCase):
         call = fake.calls[0]
         self.assertEqual(call['ConditionExpression'], "last_modified = :lm")
         self.assertEqual(call['ExpressionAttributeValues'][':lm'], decimal.Decimal("1000"))
+        # The caller puts this same value on the game dict before broadcasting, so the
+        # direct push and the stream's copy agree on when the write happened.
+        self.assertEqual(call['ExpressionAttributeValues'][':t'], decimal.Decimal("3000"))
 
     def test_lost_condition_check_returns_false(self):
         play.table = FakeTable(error_code='ConditionalCheckFailedException')
@@ -58,6 +65,52 @@ class TestUpdateInDynamodb(unittest.TestCase):
         play.table = FakeTable(error_code='ProvisionedThroughputExceededException')
         with self.assertRaises(ClientError):
             self.update()
+
+
+
+HUMAN_A, HUMAN_B, AI = "human-a", "human-b", "ai-1"
+
+
+def roster(*players):
+    return {"players": list(players)}
+
+
+def human(uuid, nickname):
+    return {"uuid": uuid, "nickname": nickname}
+
+
+def ai(uuid, nickname):
+    return {"uuid": uuid, "nickname": nickname, "ai_agent": "conservative"}
+
+
+class TestPushToOtherPlayers(unittest.TestCase):
+    """Who gets a move ahead of the DynamoDB stream, and who waits for it."""
+
+    def setUp(self):
+        self.real_broadcast = play.broadcast_game_state
+        self.pushed = []
+        play.broadcast_game_state = lambda game, exclude_player_uuid=None: self.pushed.append(exclude_player_uuid)
+
+    def tearDown(self):
+        play.broadcast_game_state = self.real_broadcast
+
+    def test_human_move_with_another_human_watching_is_pushed(self):
+        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), HUMAN_A)
+        self.assertEqual(self.pushed, [HUMAN_A])
+
+    def test_ai_move_is_left_to_the_stream(self):
+        # AI agents invoke blef-play directly, so without this check their moves would
+        # be pushed too - most of the traffic, for a move the queue already paced.
+        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B"), ai(AI, "Dazhbog_(AI)")), AI)
+        self.assertEqual(self.pushed, [])
+
+    def test_single_human_game_is_left_to_the_stream(self):
+        play.push_to_other_players(roster(human(HUMAN_A, "A"), ai(AI, "Dazhbog_(AI)")), HUMAN_A)
+        self.assertEqual(self.pushed, [])
+
+    def test_unknown_mover_pushes_nothing(self):
+        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), "not-in-this-game")
+        self.assertEqual(self.pushed, [])
 
 
 if __name__ == "__main__":

--- a/api/test/test_play.py
+++ b/api/test/test_play.py
@@ -32,7 +32,7 @@ class TestUpdateInDynamodb(unittest.TestCase):
     def setUp(self):
         self.real_table = play.table
         self.args = ("uuid-1", "Bob", [{"player": "Alice", "action_id": 5}],
-                     decimal.Decimal("2000"), decimal.Decimal("1000"), decimal.Decimal("3000"))
+                     decimal.Decimal("2000"), decimal.Decimal("1000"))
 
     def tearDown(self):
         play.table = self.real_table
@@ -40,26 +40,27 @@ class TestUpdateInDynamodb(unittest.TestCase):
     def update(self):
         return play.update_in_dynamodb(*self.args)
 
-    def test_success_returns_true_and_guards_on_last_modified(self):
+    def test_returns_the_written_timestamp_and_guards_on_last_modified(self):
         play.table = fake = FakeTable()
-        self.assertTrue(self.update())
+        written_at = self.update()
+        self.assertIsNotNone(written_at)
         call = fake.calls[0]
         self.assertEqual(call['ConditionExpression'], "last_modified = :lm")
         self.assertEqual(call['ExpressionAttributeValues'][':lm'], decimal.Decimal("1000"))
-        # The caller puts this same value on the game dict before broadcasting, so the
-        # direct push and the stream's copy agree on when the write happened.
-        self.assertEqual(call['ExpressionAttributeValues'][':t'], decimal.Decimal("3000"))
+        # The caller puts this on the game before broadcasting, so the direct push and
+        # the stream's copy agree on when the write happened.
+        self.assertEqual(call['ExpressionAttributeValues'][':t'], written_at)
 
-    def test_lost_condition_check_returns_false(self):
+    def test_lost_condition_check_returns_none(self):
         play.table = FakeTable(error_code='ConditionalCheckFailedException')
-        self.assertFalse(self.update())
+        self.assertIsNone(self.update())
 
     def test_transaction_conflict_returns_false(self):
         # A timeout ending the round runs transact_write_items; DynamoDB rejects
         # singleton writes to the same item while that is in flight. The play
         # lost the race, so it must not surface as a 500.
         play.table = FakeTable(error_code='TransactionConflictException')
-        self.assertFalse(self.update())
+        self.assertIsNone(self.update())
 
     def test_other_client_errors_propagate(self):
         play.table = FakeTable(error_code='ProvisionedThroughputExceededException')
@@ -89,27 +90,27 @@ class TestPushToOtherPlayers(unittest.TestCase):
     def setUp(self):
         self.real_broadcast = play.broadcast_game_state
         self.pushed = []
-        play.broadcast_game_state = lambda game, exclude_player_uuid=None: self.pushed.append(exclude_player_uuid)
+        play.broadcast_game_state = lambda game: self.pushed.append(game)
 
     def tearDown(self):
         play.broadcast_game_state = self.real_broadcast
 
-    def test_human_move_with_another_human_watching_is_pushed(self):
-        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), HUMAN_A)
-        self.assertEqual(self.pushed, [HUMAN_A])
+    def test_human_move_is_pushed(self):
+        play.broadcast_human_move(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), HUMAN_A)
+        self.assertEqual(len(self.pushed), 1)
 
     def test_ai_move_is_left_to_the_stream(self):
         # AI agents invoke blef-play directly, so without this check their moves would
         # be pushed too - most of the traffic, for a move the queue already paced.
-        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B"), ai(AI, "Dazhbog_(AI)")), AI)
+        play.broadcast_human_move(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B"), ai(AI, "Dazhbog_(AI)")), AI)
         self.assertEqual(self.pushed, [])
 
-    def test_single_human_game_is_left_to_the_stream(self):
-        play.push_to_other_players(roster(human(HUMAN_A, "A"), ai(AI, "Dazhbog_(AI)")), HUMAN_A)
-        self.assertEqual(self.pushed, [])
+    def test_single_human_game_is_pushed_too(self):
+        play.broadcast_human_move(roster(human(HUMAN_A, "A"), ai(AI, "Dazhbog_(AI)")), HUMAN_A)
+        self.assertEqual(len(self.pushed), 1)
 
     def test_unknown_mover_pushes_nothing(self):
-        play.push_to_other_players(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), "not-in-this-game")
+        play.broadcast_human_move(roster(human(HUMAN_A, "A"), human(HUMAN_B, "B")), "not-in-this-game")
         self.assertEqual(self.pushed, [])
 
 

--- a/api/test/test_readiness.py
+++ b/api/test/test_readiness.py
@@ -8,6 +8,10 @@ import decimal
 import unittest
 
 os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+# set_readiness broadcasts, so it pulls in shared.websocket's endpoint construction
+os.environ.setdefault("AWS_REGION", "eu-west-2")
+os.environ.setdefault("watch_game_websocket_api_id", "abc123")
+os.environ.setdefault("watch_game_websocket_api_stage", "production")
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import set_readiness  # noqa: E402
 import shared.game as game_module  # noqa: E402
@@ -98,12 +102,16 @@ class TestReadinessHandler(unittest.TestCase):
         self.real_table = set_readiness.table
         self.real_get = decorators.get_from_dynamodb
         self.real_start = set_readiness.start_game
+        self.real_broadcast = set_readiness.broadcast_game_state
+        self.broadcasts = []
         set_readiness.start_game = lambda game: True
+        set_readiness.broadcast_game_state = lambda game: self.broadcasts.append(game)
 
     def tearDown(self):
         set_readiness.table = self.real_table
         decorators.get_from_dynamodb = self.real_get
         set_readiness.start_game = self.real_start
+        set_readiness.broadcast_game_state = self.real_broadcast
 
     def call(self, game):
         decorators.get_from_dynamodb = lambda _uuid: copy.deepcopy(game)
@@ -116,6 +124,19 @@ class TestReadinessHandler(unittest.TestCase):
         resp = self.call(lobby())
         self.assertEqual(resp["statusCode"], 200)
         self.assertEqual(len(fake.calls), 1)
+
+    def test_the_new_state_is_pushed_to_watchers(self):
+        # This endpoint returns only a message, so the websocket push is how anyone
+        # (including the player who called it) learns the readiness changed.
+        set_readiness.table = FakeTable()
+        self.call(lobby())
+        self.assertEqual(len(self.broadcasts), 1)
+
+    def test_a_refused_write_pushes_nothing(self):
+        set_readiness.table = FakeTable(error_code='ConditionalCheckFailedException', fail_times=1)
+        resp = self.call(lobby())
+        self.assertEqual(resp["statusCode"], 409)
+        self.assertEqual(self.broadcasts, [])
 
     def test_lost_race_reports_conflict(self):
         # The roster shifted, so the write was refused rather than landing on the

--- a/api/test/test_websocket.py
+++ b/api/test/test_websocket.py
@@ -1,0 +1,97 @@
+# Unit tests for shared.websocket's broadcast helper.
+# No network / AWS needed (the management API and the table are stubbed). Run from
+# the api/ directory:
+#   python test/test_websocket.py
+import os
+import sys
+import json
+import unittest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-2")
+os.environ.setdefault("AWS_REGION", "eu-west-2")
+os.environ.setdefault("watch_game_websocket_api_id", "abc123")
+os.environ.setdefault("watch_game_websocket_api_stage", "production")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import shared.websocket as ws  # noqa: E402
+
+CONNECTION_ID = "Y_dxWcOZrPECECg="
+
+
+class GoneException(Exception):
+    pass
+
+
+class FakeApiGateway:
+    exceptions = type("Exceptions", (), {"GoneException": GoneException})
+
+    def __init__(self, raises=None):
+        self.raises = raises
+        self.calls = []
+
+    def post_to_connection(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises:
+            raise self.raises("boom")
+
+
+class FakeTable:
+    def __init__(self):
+        self.deleted = []
+
+    def delete_item(self, **kwargs):
+        self.deleted.append(kwargs["Key"])
+
+
+class TestPostToConnection(unittest.TestCase):
+
+    def setUp(self):
+        self.real_api, self.real_table = ws.apigateway, ws.websocket_table
+        ws.websocket_table = self.table = FakeTable()
+
+    def tearDown(self):
+        ws.apigateway, ws.websocket_table = self.real_api, self.real_table
+
+    def post(self):
+        return ws.post_to_connection({"status": "Running"}, CONNECTION_ID)
+
+    def test_delivers_the_payload_wrapped_in_a_200(self):
+        ws.apigateway = fake = FakeApiGateway()
+        self.post()
+
+        call = fake.calls[0]
+        self.assertEqual(call["ConnectionId"], CONNECTION_ID)
+        self.assertEqual(json.loads(json.loads(call["Data"])["body"])["status"], "Running")
+        self.assertEqual(self.table.deleted, [])
+
+    def test_gone_connection_is_forgotten(self):
+        # Otherwise a client that dropped costs a failed post on every future
+        # broadcast, for as long as the game is still being played.
+        ws.apigateway = FakeApiGateway(raises=GoneException)
+        self.post()
+        self.assertEqual(self.table.deleted, [{"connection_id": CONNECTION_ID}])
+
+    def test_other_failures_keep_the_connection(self):
+        # A throttle or a transient error must never cut a live watcher off.
+        for err in (RuntimeError, ValueError, ConnectionError):
+            with self.subTest(error=err.__name__):
+                ws.apigateway = FakeApiGateway(raises=err)
+                self.post()
+                self.assertEqual(self.table.deleted, [])
+
+    def test_a_failure_never_aborts_the_rest_of_the_broadcast(self):
+        for err in (GoneException, RuntimeError):
+            with self.subTest(error=err.__name__):
+                ws.apigateway = FakeApiGateway(raises=err)
+                self.assertTrue(self.post())
+
+
+class TestEndpoint(unittest.TestCase):
+
+    def test_endpoint_is_derived_not_looked_up(self):
+        # Building it from the API id keeps the API Gateway control plane off the
+        # cold-start path, where a throttle would fail every invocation.
+        self.assertEqual(ws.endpoint_url, "https://abc123.execute-api.eu-west-2.amazonaws.com/production")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/watch-chat.py
+++ b/api/watch-chat.py
@@ -1,37 +1,10 @@
-import os
-import boto3
 from boto3.dynamodb.conditions import Key
 from concurrent.futures import ThreadPoolExecutor
 import json
-from shared.response import *
 from shared.api_gateway import parse_event
 from shared.logging import logger
 from shared.db import websocket_table, get_from_dynamodb
-
-
-watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
-watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
-
-endpoint_url = f"{boto3.client('apigatewayv2').get_api(ApiId=watch_game_websocket_api_id).get('ApiEndpoint')}/{watch_game_websocket_api_stage}".replace("wss://", "https://")
-apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
-
-# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
-# network-bound, so threads parallelise well despite the GIL.
-MAX_BROADCAST_WORKERS = 16
-
-def post_to_connection(payload, connection_id):
-    logger.info('## POSTING TO CONNECTION')
-    logger.info(connection_id)
-    try:
-        apigateway.post_to_connection(
-            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
-            ConnectionId=connection_id
-        )
-    except Exception as err:
-        # A single stale/gone connection must not abort the rest of the broadcast.
-        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
-        logger.info(str(err))
-    return True
+from shared.websocket import post_to_connection, MAX_BROADCAST_WORKERS
 
 
 def broadcast_reaction(reaction_details):

--- a/api/watch-game-connect.py
+++ b/api/watch-game-connect.py
@@ -21,9 +21,8 @@ def get_game(game_uuid):
 
 
 def save_connection_object(obj):
-    now = time.time()
-    obj["last_modified"] = decimal.Decimal(str(now))
-    obj["ttl"] = int(now + CONNECTION_RETENTION_PERIOD_SECONDS)
+    obj["last_modified"] = decimal.Decimal(str(time.time()))
+    obj["ttl"] = int(time.time() + CONNECTION_RETENTION_PERIOD_SECONDS)
     websocket_table.put_item(Item=obj)
     return True
 

--- a/api/watch-game-connect.py
+++ b/api/watch-game-connect.py
@@ -9,6 +9,9 @@ from shared.logging import logger
 from shared.db import table as games_table, websocket_table
 
 
+CONNECTION_RETENTION_PERIOD_SECONDS = 3 * 60 * 60  # API Gateway's WebSocket connections can only last two hours anyway
+
+
 def get_game(game_uuid):
     response = games_table.query(KeyConditionExpression=Key('game_uuid').eq(game_uuid))
     items = response.get("Items")
@@ -18,7 +21,9 @@ def get_game(game_uuid):
 
 
 def save_connection_object(obj):
-    obj["last_modified"] = decimal.Decimal(str(time.time()))
+    now = time.time()
+    obj["last_modified"] = decimal.Decimal(str(now))
+    obj["ttl"] = int(now + CONNECTION_RETENTION_PERIOD_SECONDS)
     websocket_table.put_item(Item=obj)
     return True
 

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -9,23 +9,14 @@ from shared.api_gateway import parse_event
 from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, is_update_redundant
 from shared.logging import logger
 from shared.db import websocket_table
+from shared.websocket import post_to_connection, MAX_BROADCAST_WORKERS
 
 sqs_client = boto3.client("sqs")
 AIAGENT_QUEUE_NAME = os.environ.get("aiagent_queue_name")
 
-# Upper bound on concurrent websocket posts per broadcast. PostToConnection is
-# network-bound, so threads parallelise well despite the GIL.
-MAX_BROADCAST_WORKERS = 16
-
 # Cached lazily on first use so the queue URL is resolved once per container
 # (and captured by the SnapStart snapshot) instead of on every broadcast.
 _aiagent_queue_url = None
-
-watch_game_websocket_api_id = os.environ.get("watch_game_websocket_api_id")
-watch_game_websocket_api_stage = os.environ.get("watch_game_websocket_api_stage")
-
-endpoint_url = f"{boto3.client('apigatewayv2').get_api(ApiId=watch_game_websocket_api_id).get('ApiEndpoint')}/{watch_game_websocket_api_stage}".replace("wss://", "https://")
-apigateway = boto3.client('apigatewaymanagementapi', endpoint_url=endpoint_url)
 
 deserializer = boto3.dynamodb.types.TypeDeserializer()
 
@@ -96,20 +87,6 @@ def find_connected_public_games_watchers():
         IndexName="game_uuid-index"
     )
     return [(connection["connection_id"]) for connection in response.get("Items")]
-
-
-def post_to_connection(payload, connection_id):
-    logger.info('## POSTING TO CONNECTION')
-    logger.info(connection_id)
-    try:
-        response = apigateway.post_to_connection(
-            Data=bytes(json.dumps(response_payload(200, payload), cls=DecimalEncoder), encoding="utf-8"),
-            ConnectionId=connection_id
-        )
-    except Exception as err:
-        logger.info('## ERROR: COULD NOT POST TO CONNECTION')
-        logger.info(str(err))
-    return True
 
 
 def deserialise_dynamodb_stream_event(obj):

--- a/api/watch-game-stream.py
+++ b/api/watch-game-stream.py
@@ -9,7 +9,7 @@ from shared.api_gateway import parse_event
 from shared.game import get_player_by_nickname, get_nickname_by_uuid, censor_game, is_update_redundant
 from shared.logging import logger
 from shared.db import websocket_table
-from shared.websocket import post_to_connection, MAX_BROADCAST_WORKERS
+from shared.websocket import post_to_connection, broadcast_game_state, MAX_BROADCAST_WORKERS
 
 sqs_client = boto3.client("sqs")
 AIAGENT_QUEUE_NAME = os.environ.get("aiagent_queue_name")
@@ -53,18 +53,6 @@ def send_queue_message(game):
         return
 
 
-def find_connected_players(game):
-    game_uuid = game["game_uuid"]
-    if isinstance(game_uuid, dict):
-        game_uuid = game_uuid.get("S")
-    watched_game_uuid = game_uuid.split("_")[0]
-    response = websocket_table.query(
-        KeyConditionExpression=Key('game_uuid').eq(watched_game_uuid),
-        IndexName="game_uuid-index"
-    )
-    return [(connection["connection_id"], connection["player_uuid"]) for connection in response.get("Items", [])]
-
-
 def get_public_game_info(game):
     public_game_info = {
         "game_uuid": game["game_uuid"],
@@ -93,22 +81,6 @@ def deserialise_dynamodb_stream_event(obj):
     return {k: deserializer.deserialize(v) for k,v in obj.items()}
 
 
-def update_game_watchers(game):
-    connected_players = find_connected_players(game)
-    logger.info('## CONNECTED PLAYERS')
-    logger.info(connected_players)
-    if not connected_players:
-        return
-
-    def post_player_update(connected_player):
-        connection_id, player_uuid = connected_player
-        player_nickname = get_nickname_by_uuid(game["players"], player_uuid)
-        post_to_connection(censor_game(game, player_nickname), connection_id)
-
-    with ThreadPoolExecutor(max_workers=min(len(connected_players), MAX_BROADCAST_WORKERS)) as executor:
-        list(executor.map(post_player_update, connected_players))
-
-
 def update_public_games_watchers(game, game_old):
     logger.info('## UPDATING PUBLIC GAMES WATCHERS')
     if not can_get_public_info(game, game_old):
@@ -122,7 +94,7 @@ def update_public_games_watchers(game, game_old):
 
 
 def update_watchers(game):
-    update_game_watchers(game["new"])
+    broadcast_game_state(game["new"])
     update_public_games_watchers(game["new"], game["old"])
 
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -70,5 +70,16 @@ concurrently through a bounded, throttle-safe worker pool (see the script header
 Reports are reviewed by the maintainers pulling straight from DynamoDB. `deployment/fetch_reports.py` scans the table, prints reports that arrived since its last run, and flags reported nicknames that pass the current profanity filter (blocklist candidates).
 
 
+### Websocket connection expiry (one-time setup)
+
+`watch_game_websocket_manager` needs TTL enabled on the `ttl` attribute:
+
+```bash
+aws dynamodb update-time-to-live --table-name watch_game_websocket_manager \
+  --time-to-live-specification "Enabled=true, AttributeName=ttl"
+```
+
+This is only a backstop. When a broadcast is refused because of a dropped connection, the connection is deleted from the table by a separate mechanism.
+
 ### Architecture overview
 ![Blef architecture](https://user-images.githubusercontent.com/10632991/146104548-3e4693ab-4889-43c2-b7a0-e4d47d52fb36.png)


### PR DESCRIPTION
Built on top of #245.

Currently, WebSocket pushes happen with a very bad lag because of the DynamoDB streams, which typically add around 300ms. In a 4-person game, over 1 person-minute is wasted waiting for the stream. What's worse, if you sit with the other players in a room, you experience the lag directly as your friend pushes a button and you wait to see their action on your screen.

Thankfully, recent conditional updates and WebSocket PRs made it easy to implement this: instant WebSocket broadcasts from two endpoints that account for most traffic: `play` and `set-readiness`. The broadcasts are launched after the update is successfully written.

This is the simplest implementation that doesn't prevent the duplicated broadcast from `watch-game-stream`. However:
* `play` already returns the game state to the moving player as an earlier latency mitigation mechanism
* AI moves are intentionally delayed and you don't sit with the AI in one room either

Therefore, instant broadcasts in `play` happen strictly after a human move in a game with at least 2 humans.

For almost anyone in the world, this will improve performance more than moving the engine to their country. In fact, given intra-AWS operations are on low double digits, this should remove most of the lag.

The PR also fixes the `last_modified` timestamp in the `play` endpoint response and adds a few tests for recent changes